### PR TITLE
팰월드 게임 로그(Pal.log) 미생성 정상화 - NSSM -log 플래그 및 Flask 자가 치유

### DIFF
--- a/suh-ai-server/flask/config/palworld_config.py
+++ b/suh-ai-server/flask/config/palworld_config.py
@@ -27,6 +27,15 @@ PUBLIC_PORT = 8211
 SERVICE_NAME = "PalServer"
 REST_BASE_URL = "http://127.0.0.1:8212"
 
+# NSSM 서비스가 PalServer-Win64-Shipping-Cmd.exe에 넘겨야 하는 실행 인자(정본).
+# -log: 언리얼 엔진이 Pal\Saved\Logs\Pal.log를 디스크에 기록하도록 강제한다.
+#       이 플래그가 없으면 게임 로그 파일이 아예 생성되지 않는다.
+# setup-palworld.ps1과 이 값이 일치해야 하며, Flask(SYSTEM 권한)가 서버 시작/재시작 시
+# NSSM AppParameters에 -log가 빠져 있으면 이 값으로 자가 치유한다.
+PALSERVER_ARGS = "-port=8211 -players=32 -log -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
+REQUIRED_ARG_FLAG = "-log"
+NSSM_PATH = r"C:\ProgramData\chocolatey\bin\nssm.exe"
+
 # OptionSettings에서 문자열로 취급해 따옴표를 붙여야 하는 키
 STRING_KEYS = {
     "ServerName", "ServerDescription", "AdminPassword", "ServerPassword",

--- a/suh-ai-server/flask/service/palworld_service.py
+++ b/suh-ai-server/flask/service/palworld_service.py
@@ -14,6 +14,7 @@ from config.palworld_config import (
     INI_PATH, SAVE_DIR, BACKUP_DIR, LOG_SOURCES,
     SERVICE_NAME, REST_BASE_URL, EDITABLE_KEYS,
     PUBLIC_HOST, PUBLIC_PORT,
+    PALSERVER_ARGS, REQUIRED_ARG_FLAG, NSSM_PATH,
 )
 from service.palworld_ini import parse_option_settings, update_option_settings
 
@@ -47,14 +48,61 @@ class PalworldService:
         if result.returncode != 0:
             raise RuntimeError(f'{verb}-Service failed: {result.stderr.strip()}')
 
+    # --- NSSM 실행 인자 자가 치유 ---
+
+    @staticmethod
+    def _needs_log_flag(current_args: str) -> bool:
+        """현재 NSSM AppParameters 문자열에 -log 플래그가 빠졌는지 (공백 경계로 판정)."""
+        tokens = (current_args or '').split()
+        return REQUIRED_ARG_FLAG not in tokens
+
+    def _get_nssm_parameters(self) -> str:
+        result = subprocess.run(
+            [NSSM_PATH, 'get', SERVICE_NAME, 'AppParameters'],
+            capture_output=True, text=True, timeout=15
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f'nssm get AppParameters failed: {result.stderr.strip()}')
+        # nssm은 UTF-16LE로 출력하는 경우가 있어 text=True로도 NUL이 섞일 수 있다 → 정리
+        return result.stdout.replace('\x00', '').strip()
+
+    def ensure_log_enabled(self) -> bool:
+        """서버 시작/재시작 전에 NSSM 실행 인자에 -log가 있는지 보장한다.
+
+        Flask는 LocalSystem 권한으로 돌기 때문에 nssm set이 가능하다.
+        이미 -log가 있으면 아무것도 하지 않고 False, 새로 넣었으면 True를 반환한다.
+        치유에 실패해도 서버 제어 자체를 막지 않도록 예외는 삼키고 경고만 남긴다.
+        """
+        try:
+            current = self._get_nssm_parameters()
+            if not self._needs_log_flag(current):
+                return False
+            result = subprocess.run(
+                [NSSM_PATH, 'set', SERVICE_NAME, 'AppParameters', PALSERVER_ARGS],
+                capture_output=True, text=True, timeout=15
+            )
+            if result.returncode != 0:
+                logger.warning(f'nssm set AppParameters failed (권한 부족 가능): {result.stderr.strip()}')
+                return False
+            logger.info(f'NSSM AppParameters 자가 치유: -log 추가됨 → {PALSERVER_ARGS}')
+            return True
+        except Exception as e:
+            logger.warning(f'ensure_log_enabled 실패: {e}')
+            return False
+
     def start(self):
+        self.ensure_log_enabled()
         self._service_command('Start')
 
     def stop(self):
         self._service_command('Stop')
 
     def restart(self):
+        healed = self.ensure_log_enabled()
+        # -log를 새로 넣었다면 반드시 프로세스를 완전히 재기동해야 인자가 적용된다.
+        # Restart-Service는 stop→start라 새 AppParameters로 뜬다.
         self._service_command('Restart')
+        return {'log_flag_added': healed}
 
     # --- 상태 (공식 REST API 중계) ---
 

--- a/suh-ai-server/flask/test/test_palworld_service.py
+++ b/suh-ai-server/flask/test/test_palworld_service.py
@@ -83,10 +83,74 @@ def test_get_status_degrades_when_rest_down(service):
 
 
 def test_start_calls_powershell(service):
-    with patch('service.palworld_service.subprocess.run', return_value=_sc_result("", 0)) as mock_run:
+    # start()는 ensure_log_enabled() 후 Start-Service를 호출한다.
+    with patch.object(service, 'ensure_log_enabled', return_value=False), \
+         patch('service.palworld_service.subprocess.run', return_value=_sc_result("", 0)) as mock_run:
         service.start()
     args = mock_run.call_args[0][0]
     assert 'Start-Service' in ' '.join(args)
+
+
+# --- NSSM -log 자가 치유 ---
+
+def test_needs_log_flag_true_when_absent(service):
+    assert service._needs_log_flag("-port=8211 -players=32 -useperfthreads") is True
+
+
+def test_needs_log_flag_false_when_present(service):
+    assert service._needs_log_flag("-port=8211 -log -players=32") is False
+
+
+def test_needs_log_flag_not_fooled_by_substring(service):
+    # -logcmds 같은 다른 플래그가 -log로 오인되면 안 된다 (토큰 경계 판정)
+    assert service._needs_log_flag("-port=8211 -logcmds=x -players=32") is True
+
+
+def test_needs_log_flag_handles_empty(service):
+    assert service._needs_log_flag("") is True
+    assert service._needs_log_flag(None) is True
+
+
+def test_ensure_log_enabled_adds_flag_when_missing(service):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == 'get':
+            return _sc_result("-port=8211 -players=32 -useperfthreads", 0)
+        return _sc_result("", 0)  # set
+
+    with patch('service.palworld_service.subprocess.run', side_effect=fake_run):
+        added = service.ensure_log_enabled()
+    assert added is True
+    set_calls = [c for c in calls if c[1] == 'set']
+    assert set_calls, 'nssm set이 호출되어야 한다'
+    assert '-log' in set_calls[0][-1]
+
+
+def test_ensure_log_enabled_noop_when_present(service):
+    def fake_run(cmd, **kwargs):
+        assert cmd[1] != 'set', 'already has -log → set 호출 금지'
+        return _sc_result("-port=8211 -log -players=32", 0)
+
+    with patch('service.palworld_service.subprocess.run', side_effect=fake_run):
+        added = service.ensure_log_enabled()
+    assert added is False
+
+
+def test_ensure_log_enabled_swallows_errors(service):
+    # 권한 부족 등으로 실패해도 예외를 던지지 않고 False를 반환해 서버 제어를 막지 않는다
+    with patch('service.palworld_service.subprocess.run', side_effect=Exception("access denied")):
+        assert service.ensure_log_enabled() is False
+
+
+def test_restart_heals_before_restarting(service):
+    with patch.object(service, 'ensure_log_enabled', return_value=True) as heal, \
+         patch('service.palworld_service.subprocess.run', return_value=_sc_result("", 0)) as mock_run:
+        result = service.restart()
+    heal.assert_called_once()
+    assert result == {'log_flag_added': True}
+    assert 'Restart-Service' in ' '.join(mock_run.call_args[0][0])
 
 
 # --- tail_logs (source 선택 + seek tail) ---

--- a/suh-ai-server/scripts/setup-palworld.ps1
+++ b/suh-ai-server/scripts/setup-palworld.ps1
@@ -91,12 +91,15 @@ if (-not $nssmPath) {
     exit 1
 }
 $existing = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+# -log: 언리얼 엔진이 Pal\Saved\Logs\Pal.log 파일을 디스크에 기록하도록 강제한다.
+# 이 플래그가 없으면 엔진 로그는 콘솔(GLog)로만 흘러 Pal.log가 아예 생성되지 않는다.
+$palServerArgs = "-port=8211 -players=32 -log -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
 if (-not $existing) {
-    & nssm install $serviceName $palServerShippingExe "-port=8211 -players=32 -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
+    & nssm install $serviceName $palServerShippingExe $palServerArgs
     Write-Host "[SUCCESS] NSSM service '$serviceName' created"
 } else {
     & nssm set $serviceName Application $palServerShippingExe
-    & nssm set $serviceName AppParameters "-port=8211 -players=32 -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
+    & nssm set $serviceName AppParameters $palServerArgs
     Write-Host "[INFO] Service '$serviceName' already exists - reapplying configuration"
 }
 


### PR DESCRIPTION
## 개요

팰월드 게임 로그(`Pal.log`)가 디스크에 전혀 생성되지 않던 문제를 근본 원인부터 해결한다.

- https://github.com/Cassiiopeia/suh-project-control/issues/56

## 근본 원인

라이브 서버에서 확인: NSSM 서비스가 PalServer를 `-log` 없이 기동하고 있었다. 언리얼 엔진은 `-log` 인자가 있어야만 `Pal\Saved\Logs\Pal.log`를 파일로 기록한다. 그래서 게임 로그 파일이 아예 만들어지지 않았고, 관리자 페이지 게임 로그 탭이 "로그 파일이 아직 없습니다"를 표시했다.

## 변경 사항

- **`setup-palworld.ps1`**: NSSM `AppParameters`에 `-log` 추가 (신규 설치·기존 서비스 재설정 모두 정본 변수 사용)
- **`palworld_config.py`**: `PALSERVER_ARGS`(정본 인자, `-log` 포함) · `REQUIRED_ARG_FLAG` · `NSSM_PATH` 추가
- **`palworld_service.py`**: `ensure_log_enabled()` — 서버 시작/재시작 시 NSSM 인자에 `-log`가 빠져 있으면 Flask(LocalSystem 권한)가 `nssm set`으로 **자가 치유**한다. 관리자가 수동 조치 없이 UI에서 재시작만 해도 로그가 정상화된다.
  - 토큰 경계 판정으로 `-logcmds` 같은 유사 플래그 오인 방지
  - 치유 실패(권한 부족 등) 시 예외를 삼켜 서버 제어 자체는 막지 않음

## 테스트

- `ensure_log_enabled` / `_needs_log_flag` 단위 테스트 8건 추가
- flask 전체 테스트 57건 통과

## 배포 후 조치

배포로 Flask가 갱신되면 관리자 페이지에서 **서버 재시작** 1회 → `-log` 자가 치유 → `Pal.log` 생성 확인.
