### PR TITLE
팰월드 관리자 대시보드 정보 대폭 확충 - 성능지표·플레이어상세·메트릭 히스토리 그래프

### DIFF
--- a/docs/superpowers/specs/2026-07-14-palworld-admin-dashboard-expansion-design.md
+++ b/docs/superpowers/specs/2026-07-14-palworld-admin-dashboard-expansion-design.md
@@ -1,0 +1,59 @@
+# 팰월드 관리자 대시보드 대폭 확충 — 설계 (Issue #57 게임로그 정상화 후속)
+
+작성일: 2026-07-14
+관련: 게임로그 정상화(#56/PR#57), 대시보드 확충(신규 이슈), 로그 뷰어 강화(신규 이슈)
+
+## 목표
+
+관리자 화면에서 팰월드 서버의 **가능한 모든 정보를 추적·조회**할 수 있게 한다.
+현재는 접속자 수 / FPS / 업타임 / (이름·레벨·Ping) 3열 플레이어 표만 노출된다.
+PalServer 공식 REST API(`/info` `/players` `/metrics` `/settings`)는 훨씬 많은 데이터를 제공하므로 이를 전면 노출하고, 시간에 따른 추이를 그래프로 본다. 기존의 깔끔한 DaisyUI 레이아웃 톤은 유지한다.
+
+## 범위 (두 이슈로 분리)
+
+### 이슈 A — 대시보드 정보 확충 + 메트릭 히스토리
+1. **서버 성능 지표 확충**: 평균 FPS, 프레임타임(ms), 인게임 일수(days), 거점 수(basecampnum), 최대 인원. `/metrics` 전량.
+2. **플레이어 상세**: 이름·레벨·Ping에 더해 계정명(Steam 닉)·SteamID(userId)·IP·월드 좌표(X/Y). `/players` 전량. 민감정보(IP·SteamID)는 노출하되 표에 정리.
+3. **월드/서버 정보**: 게임 버전, 월드 GUID, 서버명/설명, 자동저장 주기, 크로스플레이 플랫폼, 난이도, PvP 여부 등 `/info`+`/settings` 요약 카드.
+4. **메트릭 시계열 히스토리 + 그래프**: 서버가 순간값만 주므로 Flask가 주기적으로 metrics 스냅샷을 링버퍼(+jsonl 영속)에 적재. `/palworld/history` 엔드포인트로 최근 N개 반환. 프론트는 인라인 SVG 스파크라인으로 FPS·접속자 추이를 그림(외부 차트 라이브러리 없이).
+5. **이벤트 폴러 강화**: `userId`(정확한 camelCase 키)로 플레이어 식별, 이벤트에 레벨·steamId 포함.
+
+### 이슈 B — 로그 뷰어 검색/필터 + 시스템 로그
+1. 로그 뷰어에 **검색어 필터**(입력창) + 레벨 필터(전체/에러/경고) + 매칭 하이라이트.
+2. **시스템 로그 소스 추가**: Flask 앱 자체 로그(nssm-stderr.log 등)를 관리자에서 조회. 별도 로그 페이지/소스로.
+3. 접속 이력 타임라인(events 기반)을 읽기 좋은 카드/타임라인로.
+
+## 아키텍처
+
+### 백엔드
+- `PalworldMetricsHistory` (신규 service): 스레드 안전 링버퍼(deque, maxlen=N) + jsonl 영속(재기동 복구). 이벤트 폴러 틱마다 metrics 스냅샷 push.
+  - 저장 필드: ts, currentplayernum, serverfps, serverfpsaverage, serverframetime, days, basecampnum, uptime.
+  - `history(limit)` → 최근 limit개 리스트.
+  - 파일: `C:\AI\palworld\logs\palworld-metrics.jsonl`, 크기 상한 회전.
+- `PalworldService.get_status()`: 기존 info/players/metrics에 **settings 요약**과 **history 링크용 메타** 추가. players는 전체 필드 유지(프론트가 선택 렌더).
+- 신규 라우트: `GET /palworld/history?limit=120` → `{points:[...]}`.
+- 이벤트 폴러: metrics 히스토리 적재를 겸함(폴 간격 10초 → 히스토리 해상도 10초). player key를 `userId`로 정정.
+
+### 프론트
+- `palworld.html`: 상태 카드에 지표 6종, 새 "월드/서버 정보" 카드, 플레이어 탭 컬럼 확장, 상태 카드 하단 스파크라인 2개(FPS/접속자).
+- `palworld.js`: `refreshStatus`가 확장 필드 렌더 + `loadHistory()`로 스파크라인 갱신. 인라인 SVG 스파크라인 헬퍼.
+- `log-viewer.js`: 검색 입력 + 레벨 필터 + 하이라이트 추가(공용이므로 Flask 로그 페이지에도 자동 반영).
+
+## 데이터 흐름
+폴러 틱(10s) → REST /metrics 조회 → 히스토리 push(+jsonl append) → 프론트 5s refreshStatus + history fetch → SVG 스파크라인.
+
+## 안전/성능
+- 히스토리 파일 회전(상한 초과 시 .1 백업). 링버퍼 maxlen로 메모리 고정.
+- REST 실패 시 히스토리 push 스킵(구멍 허용), 상태 카드는 degrade.
+- 민감정보(IP/SteamID)는 관리자 인증 뒤에서만 노출(기존 admin nginx 인증 유지).
+
+## 테스트
+- 히스토리 링버퍼 push/limit/회전 단위 테스트.
+- 폴러 metrics 적재 테스트.
+- get_status settings 요약 포함 테스트.
+- 로그 뷰어 검색 필터는 프론트 로직(수동/경량).
+
+## 비범위 (YAGNI)
+- 장기 시계열 DB(수개월). jsonl 링버퍼로 충분.
+- 실시간 WebSocket 푸시. 폴링으로 충분.
+- 플레이어 위치 지도 오버레이(좌표 숫자 노출까지만).

--- a/suh-ai-server/flask/config/palworld_config.py
+++ b/suh-ai-server/flask/config/palworld_config.py
@@ -18,7 +18,15 @@ LOG_SOURCES = {
     "game":   os.path.join(PALSERVER_DIR, "Pal", "Saved", "Logs", "Pal.log"),
     "stdout": os.path.join(PALWORLD_BASE_DIR, "logs", "palserver-stdout.log"),
     "stderr": os.path.join(PALWORLD_BASE_DIR, "logs", "palserver-stderr.log"),
+    # Flask 앱(관리자 서버) 자체 로그 — NSSM 리다이렉트. 관리자 시스템 로그 조회용.
+    "flask":  os.path.join(r"C:\AI\suh-ai-server", "flask", "logs", "nssm-stderr.log"),
 }
+
+# 메트릭 시계열 히스토리 (FPS·접속자·프레임타임 추이 그래프용).
+# 서버 REST는 순간값만 주므로 폴러가 주기적으로 스냅샷을 이 파일에 적재한다.
+METRICS_HISTORY_FILE = os.path.join(PALWORLD_BASE_DIR, "logs", "palworld-metrics.jsonl")
+METRICS_HISTORY_MAXLEN = 720          # 링버퍼 길이 (10초 간격 × 720 = 약 2시간)
+METRICS_HISTORY_MAX_BYTES = 5 * 1024 * 1024
 
 # 게임 접속 가이드에 표시할 공개 주소
 PUBLIC_HOST = "suh-project.synology.me"

--- a/suh-ai-server/flask/router/palworld_router.py
+++ b/suh-ai-server/flask/router/palworld_router.py
@@ -3,6 +3,7 @@ Palworld server management router
 """
 from flask import Blueprint, request, jsonify
 from service.palworld_service import PalworldService, ServerRunningError
+from service.palworld_metrics_history import metrics_history
 import logging
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,21 @@ def guide():
         return jsonify(palworld_service.get_guide_info()), 200
     except Exception as e:
         logger.error(f"Guide error: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
+
+@palworld_bp.route('/palworld/history', methods=['GET'])
+def history():
+    """메트릭 시계열 히스토리 (FPS·접속자·프레임타임 추이 그래프용)"""
+    try:
+        limit = int(request.args.get('limit', 120))
+    except ValueError:
+        return jsonify({'error': 'limit must be an integer'}), 400
+    limit = max(1, min(limit, 720))
+    try:
+        return jsonify({'points': metrics_history.history(limit)}), 200
+    except Exception as e:
+        logger.error(f"History read error: {str(e)}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/suh-ai-server/flask/router/palworld_swagger.py
+++ b/suh-ai-server/flask/router/palworld_swagger.py
@@ -62,6 +62,19 @@ PALWORLD_SWAGGER_PATHS = {
             "responses": {"200": {"description": "조회 성공 (ini 없으면 address 외 null)"}}
         }
     },
+    "/palworld/history": {
+        "get": {
+            "tags": ["Palworld"], "summary": "메트릭 시계열 히스토리 (FPS·접속자·프레임타임 추이)",
+            "security": [{"ApiKeyAuth": []}],
+            "parameters": [
+                {"name": "limit", "in": "query", "required": False,
+                 "schema": {"type": "integer", "default": 120, "maximum": 720},
+                 "description": "최근 N개 스냅샷 (10초 간격 적재)"}
+            ],
+            "responses": {"200": {"description": "points 배열 반환"},
+                          "400": {"description": "limit 정수 아님"}}
+        }
+    },
     "/palworld/logs": {
         "get": {
             "tags": ["Palworld"], "summary": "서버 로그 tail (source 선택)",

--- a/suh-ai-server/flask/run.py
+++ b/suh-ai-server/flask/run.py
@@ -34,11 +34,12 @@ if __name__ == '__main__':
     logger.info(f"Log file: {log_file}")
     logger.info("=" * 50)
 
-    # 팰월드 접속/퇴장 이벤트 폴러 (daemon thread)
+    # 팰월드 접속/퇴장 이벤트 폴러 + 메트릭 히스토리 적재 (daemon thread)
     from service.palworld_service import PalworldService
     from service.palworld_event_poller import PalworldEventPoller
-    PalworldEventPoller(PalworldService()).start()
-    logger.info("Palworld event poller started (10s interval)")
+    from service.palworld_metrics_history import metrics_history
+    PalworldEventPoller(PalworldService(), metrics_history=metrics_history).start()
+    logger.info("Palworld event poller started (10s interval, metrics history on)")
 
     # Start production server
     serve(

--- a/suh-ai-server/flask/service/palworld_event_poller.py
+++ b/suh-ai-server/flask/service/palworld_event_poller.py
@@ -21,7 +21,9 @@ POLL_INTERVAL_SECONDS = 10
 
 
 def _player_key(player: dict):
-    return player.get('userid') or player.get('name')
+    # REST /players는 SteamID를 camelCase 'userId'로 준다. 과거 'userid'(소문자)로 읽어
+    # 항상 None이 되어 name 폴백에 의존했다 → 닉네임 변경 시 오탐. userId 우선으로 정정.
+    return player.get('userId') or player.get('userid') or player.get('name')
 
 
 def diff_players(prev: list, curr: list) -> tuple:
@@ -35,12 +37,13 @@ def diff_players(prev: list, curr: list) -> tuple:
 
 class PalworldEventPoller:
 
-    def __init__(self, service, interval: int = POLL_INTERVAL_SECONDS):
+    def __init__(self, service, interval: int = POLL_INTERVAL_SECONDS, metrics_history=None):
         self._service = service
         self._interval = interval
         self._prev_state = None
         self._prev_players = []
         self._stop = threading.Event()
+        self._metrics_history = metrics_history
 
     def start(self) -> threading.Thread:
         thread = threading.Thread(target=self._run, daemon=True, name='palworld-event-poller')
@@ -67,6 +70,8 @@ class PalworldEventPoller:
         self._prev_state = state
         if state != 'running':
             return
+        # 메트릭 히스토리 적재 (그래프용). 이벤트 처리와 독립 — 실패해도 이벤트는 계속.
+        self._record_metrics()
         players = self._fetch_players()
         if players is None:
             return  # REST 다운 — 스냅샷 유지, 다음 틱 재시도
@@ -77,9 +82,24 @@ class PalworldEventPoller:
             self._write_event({'type': 'leave', 'player': self._player_summary(player), 'count': len(players)})
         self._prev_players = players
 
+    def _record_metrics(self):
+        if self._metrics_history is None:
+            return
+        try:
+            resp = requests.get(f'{REST_BASE_URL}/v1/api/metrics',
+                                auth=self._service._rest_auth(), timeout=3)
+            resp.raise_for_status()
+            self._metrics_history.add_from_metrics(resp.json())
+        except Exception:
+            pass  # 메트릭 한 틱 놓쳐도 무방 — 그래프에 구멍만 생긴다
+
     @staticmethod
     def _player_summary(player: dict) -> dict:
-        return {'name': player.get('name'), 'level': player.get('level')}
+        return {
+            'name': player.get('name'),
+            'level': player.get('level'),
+            'steamId': player.get('userId') or player.get('userid'),
+        }
 
     def _fetch_players(self):
         try:

--- a/suh-ai-server/flask/service/palworld_metrics_history.py
+++ b/suh-ai-server/flask/service/palworld_metrics_history.py
@@ -1,0 +1,100 @@
+"""
+Palworld 메트릭 시계열 히스토리.
+PalServer REST /metrics는 순간값만 주므로, 폴러가 주기적으로 스냅샷을 이 버퍼에 적재해
+관리자 화면의 FPS·접속자·프레임타임 추이 그래프를 그린다.
+
+- 메모리: 스레드 안전 deque 링버퍼 (maxlen 고정 → 메모리 상한)
+- 영속: jsonl append (Flask 재기동 시 최근 스냅샷 복구), 크기 초과 시 1회전
+"""
+import json
+import logging
+import os
+import threading
+from collections import deque
+from datetime import datetime
+
+from config.palworld_config import (
+    METRICS_HISTORY_FILE, METRICS_HISTORY_MAXLEN, METRICS_HISTORY_MAX_BYTES,
+)
+
+logger = logging.getLogger(__name__)
+
+# 히스토리에 담을 metrics 필드 (REST /metrics 키 그대로)
+_METRIC_KEYS = (
+    'currentplayernum', 'serverfps', 'serverfpsaverage',
+    'serverframetime', 'days', 'basecampnum', 'uptime', 'maxplayernum',
+)
+
+
+def snapshot_from_metrics(metrics: dict, ts: str = None) -> dict:
+    """REST /metrics 응답 dict → 히스토리 포인트 하나. ts 없으면 현재 시각."""
+    point = {'ts': ts or datetime.now().isoformat(timespec='seconds')}
+    for key in _METRIC_KEYS:
+        if key in metrics:
+            point[key] = metrics[key]
+    return point
+
+
+class PalworldMetricsHistory:
+
+    def __init__(self, path: str = METRICS_HISTORY_FILE,
+                 maxlen: int = METRICS_HISTORY_MAXLEN,
+                 max_bytes: int = METRICS_HISTORY_MAX_BYTES):
+        self._path = path
+        self._max_bytes = max_bytes
+        self._buf = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+        self._load()
+
+    def _load(self):
+        """재기동 시 파일 끝에서 maxlen개까지 복구. 깨진 줄은 건너뛴다."""
+        if not os.path.exists(self._path):
+            return
+        try:
+            with open(self._path, 'r', encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+            for line in lines[-self._buf.maxlen:]:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self._buf.append(json.loads(line))
+                except ValueError:
+                    continue
+        except OSError as e:
+            logger.warning(f'metrics history load 실패: {e}')
+
+    def add(self, point: dict):
+        """스냅샷 하나를 버퍼에 넣고 파일에 append. 실패해도 예외를 던지지 않는다."""
+        with self._lock:
+            self._buf.append(point)
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            self._rotate_if_needed()
+            with open(self._path, 'a', encoding='utf-8') as f:
+                f.write(json.dumps(point, ensure_ascii=False) + '\n')
+        except OSError as e:
+            logger.warning(f'metrics history append 실패: {e}')
+
+    def add_from_metrics(self, metrics: dict, ts: str = None):
+        if metrics:
+            self.add(snapshot_from_metrics(metrics, ts))
+
+    def _rotate_if_needed(self):
+        if os.path.exists(self._path) and os.path.getsize(self._path) > self._max_bytes:
+            rotated = self._path + '.1'
+            if os.path.exists(rotated):
+                os.remove(rotated)
+            os.rename(self._path, rotated)
+
+    def history(self, limit: int = None) -> list:
+        with self._lock:
+            points = list(self._buf)
+        if limit is not None and limit > 0:
+            points = points[-limit:]
+        return points
+
+
+# 폴러(적재)와 라우터(조회)가 공유하는 단일 인스턴스.
+# 파일 백업 + 스레드 안전이라 프로세스 전역 공유가 안전하다.
+metrics_history = PalworldMetricsHistory()

--- a/suh-ai-server/flask/service/palworld_service.py
+++ b/suh-ai-server/flask/service/palworld_service.py
@@ -123,16 +123,18 @@ class PalworldService:
             'info': None,
             'players': [],
             'metrics': None,
+            'settings': None,
         }
         if status['state'] != 'running':
             return status
         auth = self._rest_auth()
-        # info/players/metrics를 독립적으로 조회한다. 한 엔드포인트가 실패해도
+        # info/players/metrics/settings를 독립적으로 조회한다. 한 엔드포인트가 실패해도
         # 성공한 나머지 데이터는 버리지 않는다. 하나라도 응답하면 rest_available=True.
         endpoints = {
             'info': f'{REST_BASE_URL}/v1/api/info',
             'players': f'{REST_BASE_URL}/v1/api/players',
             'metrics': f'{REST_BASE_URL}/v1/api/metrics',
+            'settings': f'{REST_BASE_URL}/v1/api/settings',
         }
         for name, url in endpoints.items():
             try:

--- a/suh-ai-server/flask/static/js/palworld.js
+++ b/suh-ai-server/flask/static/js/palworld.js
@@ -39,6 +39,11 @@ const SETTINGS_FIELDS = [
     min: '0.1', step: '0.1', description: '거점 작업 속도에 적용되는 배율' },
 ];
 
+function setText(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
 async function refreshStatus() {
   try {
     const resp = await apiFetch(API + '/status');
@@ -48,30 +53,129 @@ async function refreshStatus() {
     badge.textContent = data.state.toUpperCase();
     badge.className = 'badge ' + (data.state === 'running' ? 'badge-success' : 'badge-error');
 
-    if (data.rest_available && data.metrics) {
-      document.getElementById('stat-players').textContent = data.metrics.currentplayernum;
-      document.getElementById('stat-maxplayers').textContent = '/ ' + data.metrics.maxplayernum + ' 명';
-      document.getElementById('stat-fps').textContent = data.metrics.serverfps;
-      document.getElementById('stat-uptime').textContent = formatUptime(data.metrics.uptime);
+    const m = data.metrics;
+    if (data.rest_available && m) {
+      setText('stat-players', m.currentplayernum);
+      setText('stat-maxplayers', '/ ' + m.maxplayernum + ' 명');
+      setText('stat-fps', m.serverfps);
+      setText('stat-fpsavg', m.serverfpsaverage != null ? '평균 ' + Number(m.serverfpsaverage).toFixed(1) : '평균 -');
+      setText('stat-frametime', m.serverframetime != null ? Number(m.serverframetime).toFixed(1) : '-');
+      setText('stat-uptime', formatUptime(m.uptime));
+      setText('stat-days', m.days != null ? m.days + '일' : '-');
+      setText('stat-basecamp', m.basecampnum != null ? m.basecampnum : '-');
     } else {
-      ['stat-players', 'stat-fps', 'stat-uptime'].forEach(id =>
-        document.getElementById(id).textContent = '-');
+      ['stat-players', 'stat-fps', 'stat-frametime', 'stat-uptime', 'stat-days', 'stat-basecamp'].forEach(id => setText(id, '-'));
+      setText('stat-fpsavg', '평균 -');
     }
+    if (data.info) setText('stat-version', data.info.version || '-');
 
-    const tbody = document.getElementById('player-list');
-    if (data.players && data.players.length) {
-      tbody.innerHTML = data.players.map(p =>
-        '<tr><td>' + escapeHtml(p.name) + '</td><td>' + escapeHtml(p.level) + '</td><td>' + Math.round(p.ping) + 'ms</td></tr>'
-      ).join('');
-    } else {
-      tbody.innerHTML = '<tr><td colspan="3">접속자 없음</td></tr>';
-    }
+    renderPlayers(data.players);
+    renderWorldInfo(data);
   } catch (e) { /* 401은 modal 처리 */ }
+}
+
+function renderPlayers(players) {
+  const tbody = document.getElementById('player-list');
+  if (!tbody) return;
+  if (players && players.length) {
+    tbody.innerHTML = players.map(p => {
+      const coord = (p.location_x != null && p.location_y != null)
+        ? Math.round(p.location_x / 1000) + ', ' + Math.round(p.location_y / 1000) : '-';
+      return '<tr>' +
+        '<td>' + escapeHtml(p.name) + '</td>' +
+        '<td>' + escapeHtml(p.accountName || '-') + '</td>' +
+        '<td>' + escapeHtml(p.level) + '</td>' +
+        '<td>' + (p.ping != null ? Math.round(p.ping) + 'ms' : '-') + '</td>' +
+        '<td class="font-mono text-xs">' + escapeHtml(p.userId || '-') + '</td>' +
+        '<td class="font-mono text-xs">' + escapeHtml(p.iP || p.ip || '-') + '</td>' +
+        '<td class="font-mono text-xs">' + coord + '</td>' +
+        '</tr>';
+    }).join('');
+  } else {
+    tbody.innerHTML = '<tr><td colspan="7">접속자 없음</td></tr>';
+  }
+}
+
+/* 월드/서버 정보 카드 — info + settings 요약 */
+const WORLD_INFO_ROWS = [
+  { label: '서버 이름', get: d => d.info && d.info.servername },
+  { label: '서버 설명', get: d => d.info && d.info.description },
+  { label: '게임 버전', get: d => d.info && d.info.version },
+  { label: '월드 GUID', get: d => d.info && d.info.worldguid, mono: true },
+  { label: '난이도', get: d => d.settings && d.settings.Difficulty },
+  { label: '경험치 배율', get: d => d.settings && d.settings.ExpRate, suffix: '배' },
+  { label: '팰 포획 배율', get: d => d.settings && d.settings.PalCaptureRate, suffix: '배' },
+  { label: '자동 저장 주기', get: d => d.settings && d.settings.autoSaveSpan, suffix: '초' },
+  { label: 'PvP', get: d => d.settings && (d.settings.bIsPvP ? '켜짐' : '꺼짐') },
+  { label: '사망 페널티', get: d => d.settings && d.settings.DeathPenalty },
+  { label: '크로스플레이', get: d => d.settings && Array.isArray(d.settings.CrossplayPlatforms) ? d.settings.CrossplayPlatforms.join(' · ') : null },
+  { label: '최대 인원', get: d => d.settings && d.settings.ServerPlayerMaxNum, suffix: '명' },
+];
+
+function renderWorldInfo(data) {
+  const box = document.getElementById('world-info');
+  if (!box) return;
+  if (!data.rest_available) {
+    box.innerHTML = '<div class="opacity-60">서버 정지 중 — 정보를 불러올 수 없습니다.</div>';
+    return;
+  }
+  box.innerHTML = WORLD_INFO_ROWS.map(row => {
+    let v = row.get(data);
+    if (v == null || v === '') v = '-';
+    else if (row.suffix) v = v + row.suffix;
+    return '<div class="flex justify-between gap-3 border-b border-base-200 py-1">' +
+      '<span class="opacity-60 shrink-0">' + escapeHtml(row.label) + '</span>' +
+      '<span class="text-right ' + (row.mono ? 'font-mono text-xs break-all' : '') + '">' + escapeHtml(v) + '</span></div>';
+  }).join('');
 }
 
 function formatUptime(seconds) {
   const h = Math.floor(seconds / 3600), m = Math.floor((seconds % 3600) / 60);
   return h + 'h ' + m + 'm';
+}
+
+/* ── 메트릭 히스토리 스파크라인 (외부 라이브러리 없이 인라인 SVG) ── */
+function sparkline(container, values, opts) {
+  opts = opts || {};
+  const el = typeof container === 'string' ? document.getElementById(container) : container;
+  if (!el) return;
+  const nums = values.filter(v => typeof v === 'number' && !isNaN(v));
+  if (nums.length < 2) { el.innerHTML = '<div class="text-xs opacity-40 pt-4">데이터 수집 중…</div>'; return; }
+  const W = 300, H = 48, pad = 2;
+  const min = opts.min != null ? opts.min : Math.min.apply(null, nums);
+  const max = opts.max != null ? opts.max : Math.max.apply(null, nums);
+  const span = (max - min) || 1;
+  const stepX = (W - pad * 2) / (values.length - 1);
+  const pts = values.map((v, i) => {
+    const y = (typeof v === 'number' && !isNaN(v))
+      ? H - pad - ((v - min) / span) * (H - pad * 2) : null;
+    return { x: pad + i * stepX, y: y };
+  }).filter(p => p.y != null);
+  const line = pts.map((p, i) => (i ? 'L' : 'M') + p.x.toFixed(1) + ' ' + p.y.toFixed(1)).join(' ');
+  const area = line + ' L' + pts[pts.length - 1].x.toFixed(1) + ' ' + H + ' L' + pts[0].x.toFixed(1) + ' ' + H + ' Z';
+  const color = opts.color || 'currentColor';
+  el.innerHTML =
+    '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none" class="w-full h-full ' + (opts.klass || 'text-primary') + '">' +
+    '<path d="' + area + '" fill="' + color + '" opacity="0.12"/>' +
+    '<path d="' + line + '" fill="none" stroke="' + color + '" stroke-width="1.5" vector-effect="non-scaling-stroke"/>' +
+    '</svg>';
+}
+
+async function loadHistory() {
+  try {
+    const resp = await apiFetch(API + '/history?limit=120');
+    const data = await resp.json();
+    const points = data.points || [];
+    if (!points.length) return;
+    const fps = points.map(p => (typeof p.serverfps === 'number' ? p.serverfps : NaN));
+    const players = points.map(p => (typeof p.currentplayernum === 'number' ? p.currentplayernum : NaN));
+    sparkline('spark-fps', fps, { min: 0, max: 60, klass: 'text-success' });
+    sparkline('spark-players', players, { min: 0, klass: 'text-primary' });
+    const lastFps = [...fps].reverse().find(v => !isNaN(v));
+    const lastP = [...players].reverse().find(v => !isNaN(v));
+    setText('spark-fps-label', lastFps != null ? lastFps + ' fps' : '');
+    setText('spark-players-label', lastP != null ? lastP + ' 명' : '');
+  } catch (e) { /* ignore */ }
 }
 
 async function controlServer(action) {
@@ -299,9 +403,11 @@ async function createBackup() {
 
 document.addEventListener('DOMContentLoaded', function () {
   refreshStatus();
+  loadHistory();
   loadSettings();
   loadGuide();
   loadBackups();
   initLogViewer();
   setInterval(refreshStatus, 5000);
+  setInterval(loadHistory, 10000);
 });

--- a/suh-ai-server/flask/templates/admin/palworld.html
+++ b/suh-ai-server/flask/templates/admin/palworld.html
@@ -36,12 +36,63 @@
           <div class="stat-figure text-primary"><i data-lucide="gauge" class="size-6"></i></div>
           <div class="stat-title">서버 FPS</div>
           <div id="stat-fps" class="stat-value text-2xl">-</div>
+          <div id="stat-fpsavg" class="stat-desc">평균 -</div>
+        </div>
+        <div class="stat">
+          <div class="stat-figure text-primary"><i data-lucide="timer" class="size-6"></i></div>
+          <div class="stat-title">프레임타임</div>
+          <div id="stat-frametime" class="stat-value text-2xl">-</div>
+          <div class="stat-desc">ms / frame</div>
         </div>
         <div class="stat">
           <div class="stat-figure text-primary"><i data-lucide="clock" class="size-6"></i></div>
           <div class="stat-title">업타임</div>
           <div id="stat-uptime" class="stat-value text-2xl">-</div>
         </div>
+      </div>
+
+      <!-- 보조 지표: 인게임 일수 / 거점 수 -->
+      <div class="stats stats-horizontal w-full bg-base-200/60 text-xs">
+        <div class="stat py-2">
+          <div class="stat-title">인게임 경과일</div>
+          <div id="stat-days" class="stat-value text-lg">-</div>
+        </div>
+        <div class="stat py-2">
+          <div class="stat-title">거점 수</div>
+          <div id="stat-basecamp" class="stat-value text-lg">-</div>
+        </div>
+        <div class="stat py-2">
+          <div class="stat-title">게임 버전</div>
+          <div id="stat-version" class="stat-value text-sm font-mono pt-1">-</div>
+        </div>
+      </div>
+
+      <!-- 추이 스파크라인 (FPS / 접속자) -->
+      <div class="grid gap-3 sm:grid-cols-2 mt-1">
+        <div class="bg-base-200 rounded-box p-3">
+          <div class="flex items-center justify-between text-xs opacity-70 mb-1">
+            <span>서버 FPS 추이</span><span id="spark-fps-label" class="font-mono"></span>
+          </div>
+          <div id="spark-fps" class="h-14"></div>
+        </div>
+        <div class="bg-base-200 rounded-box p-3">
+          <div class="flex items-center justify-between text-xs opacity-70 mb-1">
+            <span>접속자 추이</span><span id="spark-players-label" class="font-mono"></span>
+          </div>
+          <div id="spark-players" class="h-14"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 월드 / 서버 정보 -->
+  <div class="card bg-base-100 shadow">
+    <div class="card-body gap-3">
+      <h2 class="card-title text-base">
+        <i data-lucide="globe" class="size-5"></i>월드 · 서버 정보
+      </h2>
+      <div id="world-info" class="grid gap-x-6 gap-y-2 sm:grid-cols-2 text-sm">
+        <div class="opacity-60">불러오는 중…</div>
       </div>
     </div>
   </div>
@@ -126,10 +177,14 @@
     <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
       <div class="overflow-x-auto">
         <table class="table table-sm">
-          <thead><tr><th>이름</th><th>레벨</th><th>Ping</th></tr></thead>
-          <tbody id="player-list"><tr><td colspan="3">-</td></tr></tbody>
+          <thead><tr>
+            <th>이름</th><th>계정(Steam)</th><th>레벨</th><th>Ping</th>
+            <th>SteamID</th><th>IP</th><th>월드 좌표</th>
+          </tr></thead>
+          <tbody id="player-list"><tr><td colspan="7">-</td></tr></tbody>
         </table>
       </div>
+      <p class="text-xs opacity-50 mt-2">SteamID·IP·좌표는 관리자만 볼 수 있는 정보입니다.</p>
     </div>
   </div>
 </div>

--- a/suh-ai-server/flask/test/test_palworld_event_poller.py
+++ b/suh-ai-server/flask/test/test_palworld_event_poller.py
@@ -33,6 +33,20 @@ def test_diff_players_falls_back_to_name_key():
     assert left == []
 
 
+def test_diff_players_uses_userId_camelcase_for_identity():
+    # 닉네임(name)이 바뀌어도 userId가 같으면 동일 인물 → join/leave 없음
+    prev = [{'userId': 'steam_1', 'name': '재석'}]
+    curr = [{'userId': 'steam_1', 'name': '로리매킬로이'}]
+    joined, left = diff_players(prev, curr)
+    assert joined == [] and left == []
+
+
+def test_player_summary_includes_steam_id():
+    summary = PalworldEventPoller._player_summary(
+        {'name': 'A', 'level': 22, 'userId': 'steam_76561198111305145'})
+    assert summary == {'name': 'A', 'level': 22, 'steamId': 'steam_76561198111305145'}
+
+
 # --- 이벤트 기록 ---
 
 @pytest.fixture
@@ -104,3 +118,44 @@ def test_tick_skips_players_when_rest_down(event_file):
         poller._tick()
     assert not event_file.exists()          # REST 다운 → 이벤트 기록 없음
     assert poller._prev_players == [{'userid': 'a', 'name': 'A'}]  # 스냅샷 유지
+
+
+# --- 메트릭 히스토리 적재 ---
+
+def test_tick_records_metrics_history(event_file):
+    service = MagicMock()
+    service.get_service_state.return_value = 'running'
+    history = MagicMock()
+    poller = PalworldEventPoller(service, metrics_history=history)
+    poller._prev_state = 'running'
+    with patch.object(poller, '_record_metrics') as rec, \
+         patch.object(poller, '_fetch_players', return_value=[]):
+        poller._tick()
+    rec.assert_called_once()
+
+
+def test_record_metrics_pushes_snapshot(event_file):
+    service = MagicMock()
+    service._rest_auth.return_value = ('admin', 'pw')
+    history = MagicMock()
+    poller = PalworldEventPoller(service, metrics_history=history)
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {'serverfps': 60, 'currentplayernum': 1}
+    fake_resp.raise_for_status.return_value = None
+    with patch('service.palworld_event_poller.requests.get', return_value=fake_resp):
+        poller._record_metrics()
+    history.add_from_metrics.assert_called_once_with({'serverfps': 60, 'currentplayernum': 1})
+
+
+def test_record_metrics_swallows_errors(event_file):
+    service = MagicMock()
+    history = MagicMock()
+    poller = PalworldEventPoller(service, metrics_history=history)
+    with patch('service.palworld_event_poller.requests.get', side_effect=Exception('down')):
+        poller._record_metrics()  # 예외 안 나야 함
+    history.add_from_metrics.assert_not_called()
+
+
+def test_record_metrics_noop_without_history(event_file):
+    poller = PalworldEventPoller(MagicMock())  # metrics_history=None
+    poller._record_metrics()  # 아무 일도 없어야 함 (예외 없이 통과)

--- a/suh-ai-server/flask/test/test_palworld_metrics_history.py
+++ b/suh-ai-server/flask/test/test_palworld_metrics_history.py
@@ -1,0 +1,83 @@
+"""test_palworld_metrics_history.py"""
+import json
+from service.palworld_metrics_history import (
+    PalworldMetricsHistory, snapshot_from_metrics,
+)
+
+SAMPLE_METRICS = {
+    'currentplayernum': 1, 'serverfps': 60, 'serverfpsaverage': 60.7,
+    'serverframetime': 16.4, 'days': 35, 'basecampnum': 1,
+    'uptime': 10116, 'maxplayernum': 32, 'ignored_extra': 'x',
+}
+
+
+def test_snapshot_extracts_known_keys_and_stamps_ts():
+    point = snapshot_from_metrics(SAMPLE_METRICS, ts='2026-07-14T18:00:00')
+    assert point['ts'] == '2026-07-14T18:00:00'
+    assert point['serverfps'] == 60
+    assert point['currentplayernum'] == 1
+    assert 'ignored_extra' not in point
+
+
+def test_add_and_history_roundtrip(tmp_path):
+    h = PalworldMetricsHistory(path=str(tmp_path / 'm.jsonl'), maxlen=10)
+    for i in range(5):
+        h.add({'ts': f't{i}', 'serverfps': 60 - i})
+    assert len(h.history()) == 5
+    assert h.history(limit=2)[-1]['serverfps'] == 56
+    assert h.history(limit=2)[0]['serverfps'] == 57
+
+
+def test_ring_buffer_respects_maxlen(tmp_path):
+    h = PalworldMetricsHistory(path=str(tmp_path / 'm.jsonl'), maxlen=3)
+    for i in range(10):
+        h.add({'ts': f't{i}', 'serverfps': i})
+    hist = h.history()
+    assert len(hist) == 3
+    assert [p['serverfps'] for p in hist] == [7, 8, 9]
+
+
+def test_persists_and_reloads_from_file(tmp_path):
+    path = str(tmp_path / 'm.jsonl')
+    h1 = PalworldMetricsHistory(path=path, maxlen=100)
+    h1.add({'ts': 't0', 'serverfps': 60})
+    h1.add({'ts': 't1', 'serverfps': 59})
+    # 새 인스턴스가 파일에서 복구
+    h2 = PalworldMetricsHistory(path=path, maxlen=100)
+    assert len(h2.history()) == 2
+    assert h2.history()[-1]['ts'] == 't1'
+
+
+def test_reload_only_keeps_last_maxlen(tmp_path):
+    path = str(tmp_path / 'm.jsonl')
+    h1 = PalworldMetricsHistory(path=path, maxlen=100)
+    for i in range(50):
+        h1.add({'ts': f't{i}', 'serverfps': i})
+    h2 = PalworldMetricsHistory(path=path, maxlen=10)
+    assert len(h2.history()) == 10
+    assert h2.history()[0]['serverfps'] == 40
+
+
+def test_reload_skips_corrupt_lines(tmp_path):
+    path = tmp_path / 'm.jsonl'
+    path.write_text('{"ts":"t0","serverfps":60}\nNOT JSON\n{"ts":"t1","serverfps":59}\n', encoding='utf-8')
+    h = PalworldMetricsHistory(path=str(path), maxlen=100)
+    assert len(h.history()) == 2
+
+
+def test_rotation_when_file_too_large(tmp_path):
+    path = str(tmp_path / 'm.jsonl')
+    h = PalworldMetricsHistory(path=path, maxlen=1000, max_bytes=200)
+    for i in range(100):
+        h.add({'ts': f't{i}', 'serverfps': i, 'pad': 'x' * 20})
+    import os
+    assert os.path.exists(path + '.1'), '회전 백업 파일이 있어야 한다'
+
+
+def test_add_from_metrics_ignores_empty(tmp_path):
+    h = PalworldMetricsHistory(path=str(tmp_path / 'm.jsonl'), maxlen=10)
+    h.add_from_metrics(None)
+    h.add_from_metrics({})
+    assert h.history() == []
+    h.add_from_metrics(SAMPLE_METRICS)
+    assert len(h.history()) == 1


### PR DESCRIPTION
## 개요

팰월드 관리자 대시보드에 서버의 거의 모든 정보를 노출하고, 시간에 따른 추이를 그래프로 본다. 기존 DaisyUI 톤은 유지.

- https://github.com/Cassiiopeia/suh-project-control/issues/59

## 변경 사항

### 백엔드
- **`PalworldMetricsHistory`** (신규): 스레드 안전 링버퍼(deque) + jsonl 영속(재기동 복구), 크기 초과 시 회전. 이벤트 폴러가 10초마다 `/metrics` 스냅샷 적재.
- **`GET /palworld/history?limit=`**: FPS·접속자·프레임타임 추이 반환.
- **`get_status`**: 기존 info/players/metrics에 `settings` 추가.
- **이벤트 폴러 정정**: 플레이어 식별 키를 `userId`(camelCase)로 정정 — 닉네임 변경 시 오탐 제거. 이벤트에 `steamId` 포함.

### 프론트
- 상태 카드: 평균 FPS·프레임타임·인게임 경과일·거점 수·게임 버전 추가.
- **FPS·접속자 추이 스파크라인** 2종 (외부 라이브러리 없이 인라인 SVG).
- **월드·서버 정보 카드**: 버전·월드 GUID·난이도·배율·자동저장·PvP·크로스플레이 등.
- 플레이어 표: 계정명(Steam 닉)·SteamID·IP·월드 좌표 컬럼 추가.

## 테스트
- 히스토리 링버퍼/영속/회전, 폴러 metrics 적재·userId 식별 단위 테스트 14건 추가
- flask 전체 71건 통과

## 설계 문서
`docs/superpowers/specs/2026-07-14-palworld-admin-dashboard-expansion-design.md`
