### PR TITLE
관리자 로그 뷰어 검색·필터 강화 및 게임 로그 정직화(stdout)·시스템 로그

### DIFF
--- a/suh-ai-server/flask/config/palworld_config.py
+++ b/suh-ai-server/flask/config/palworld_config.py
@@ -11,14 +11,18 @@ BACKUP_DIR = os.path.join(PALWORLD_BASE_DIR, "backups")
 
 # 로그 소스: 팰월드 로그 탭에서 선택 조회하는 파일들
 # events  = Flask 폴러가 자체 생성하는 접속/퇴장 이벤트 (JSON Lines)
-# game    = UE 엔진이 직접 쓰는 진짜 서버 로그 (장애 분석용)
-# stdout/stderr = NSSM 리다이렉트 (크래시·프로세스 단서)
+# game    = 엔진의 진짜 서버 로그. Palworld 데디(Pocket Pair 빌드)는 UE 파일 로그를
+#           꺼서 배포하므로 Pal/Saved/Logs/Pal.log는 생성되지 않는다(-log/-abslog 미동작).
+#           엔진 출력은 stdout으로만 나가고 NSSM이 palserver-stdout.log로 캡처하므로,
+#           "게임 로그"는 이 캡처 파일을 가리킨다.
+# stderr  = NSSM 표준에러 리다이렉트 (크래시·프로세스 단서)
+# flask   = Flask 앱(관리자 서버) 자체 로그 — 관리자 시스템 로그 조회용
+_PAL_STDOUT = os.path.join(PALWORLD_BASE_DIR, "logs", "palserver-stdout.log")
 LOG_SOURCES = {
     "events": os.path.join(PALWORLD_BASE_DIR, "logs", "palworld-events.jsonl"),
-    "game":   os.path.join(PALSERVER_DIR, "Pal", "Saved", "Logs", "Pal.log"),
-    "stdout": os.path.join(PALWORLD_BASE_DIR, "logs", "palserver-stdout.log"),
+    "game":   _PAL_STDOUT,
+    "stdout": _PAL_STDOUT,
     "stderr": os.path.join(PALWORLD_BASE_DIR, "logs", "palserver-stderr.log"),
-    # Flask 앱(관리자 서버) 자체 로그 — NSSM 리다이렉트. 관리자 시스템 로그 조회용.
     "flask":  os.path.join(r"C:\AI\suh-ai-server", "flask", "logs", "nssm-stderr.log"),
 }
 

--- a/suh-ai-server/flask/router/palworld_swagger.py
+++ b/suh-ai-server/flask/router/palworld_swagger.py
@@ -81,8 +81,8 @@ PALWORLD_SWAGGER_PATHS = {
             "security": [{"ApiKeyAuth": []}],
             "parameters": [
                 {"name": "source", "in": "query", "required": False,
-                 "schema": {"type": "string", "enum": ["events", "game", "stdout", "stderr"], "default": "game"},
-                 "description": "events=접속/퇴장 이벤트, game=Pal.log, stdout/stderr=NSSM 리다이렉트"},
+                 "schema": {"type": "string", "enum": ["events", "game", "stdout", "stderr", "flask"], "default": "game"},
+                 "description": "events=접속/퇴장 이벤트, game=엔진 로그(stdout 캡처), stderr=NSSM 표준에러, flask=관리자 서버 로그"},
                 {"name": "lines", "in": "query", "required": False,
                  "schema": {"type": "integer", "default": 200, "maximum": 500}}
             ],

--- a/suh-ai-server/flask/static/js/log-viewer.js
+++ b/suh-ai-server/flask/static/js/log-viewer.js
@@ -1,14 +1,25 @@
 /* 공용 로그 뷰어 — 팰월드 로그 탭 / Flask 로그 페이지에서 사용.
-   소스 전환, 라인 수, 자동 새로고침(10초), Error/Warning 하이라이트,
-   맨 아래일 때만 자동 스크롤, 파일 경로·크기 표시, 파일 없으면 경로 안내. */
+   소스 전환, 라인 수, 자동 새로고침(10초), 검색어 필터 + 매칭 하이라이트,
+   레벨 필터(전체/에러/경고), 맨 아래일 때만 자동 스크롤, 파일 경로·크기 표시. */
 function createLogViewer(rootEl, config) {
   var sources = config.sources;
   var currentSource = sources[0].id;
   var lines = 200;
+  var query = '';
+  var levelFilter = 'all';   // all | error | warn
+  var lastLogs = [];         // 마지막으로 받은 원본 로그 (필터 변경 시 재요청 없이 재렌더)
+  var lastMeta = null;
 
   rootEl.innerHTML =
     '<div class="flex flex-wrap items-center gap-2 mb-3">' +
     '<div role="tablist" class="tabs tabs-box tabs-sm" data-role="sources"></div>' +
+    '<label class="input input-sm flex items-center gap-1 w-44">' +
+    '<i data-lucide="search" class="size-4 opacity-60"></i>' +
+    '<input type="text" class="grow" placeholder="검색" data-role="search">' +
+    '</label>' +
+    '<select class="select select-sm w-24" data-role="level">' +
+    '<option value="all">전체</option><option value="error">에러</option><option value="warn">경고</option>' +
+    '</select>' +
     '<select class="select select-sm w-28" data-role="lines">' +
     '<option value="100">100줄</option><option value="200" selected>200줄</option><option value="500">500줄</option>' +
     '</select>' +
@@ -18,12 +29,16 @@ function createLogViewer(rootEl, config) {
     '<button type="button" class="btn btn-ghost btn-sm" data-role="refresh">' +
     '<i data-lucide="refresh-cw" class="size-4"></i>새로고침</button>' +
     '</div>' +
-    '<div class="text-xs opacity-60 mb-2 font-mono break-all" data-role="meta"></div>' +
+    '<div class="flex items-center justify-between text-xs opacity-60 mb-2 gap-2">' +
+    '<span class="font-mono break-all" data-role="meta"></span>' +
+    '<span data-role="count" class="shrink-0"></span>' +
+    '</div>' +
     '<pre class="bg-base-300 rounded-box text-xs leading-5 overflow-auto max-h-[28rem] p-4" data-role="view">불러오는 중…</pre>';
 
   var sourcesEl = rootEl.querySelector('[data-role="sources"]');
   var viewEl = rootEl.querySelector('[data-role="view"]');
   var metaEl = rootEl.querySelector('[data-role="meta"]');
+  var countEl = rootEl.querySelector('[data-role="count"]');
 
   sources.forEach(function (s) {
     var tab = document.createElement('button');
@@ -46,6 +61,13 @@ function createLogViewer(rootEl, config) {
     refresh();
   });
   rootEl.querySelector('[data-role="refresh"]').addEventListener('click', function () { refresh(); });
+  // 검색·레벨 필터는 재요청 없이 마지막 로그를 다시 렌더 (즉각 반응)
+  rootEl.querySelector('[data-role="search"]').addEventListener('input', function (e) {
+    query = e.target.value; render();
+  });
+  rootEl.querySelector('[data-role="level"]').addEventListener('change', function (e) {
+    levelFilter = e.target.value; render();
+  });
 
   function levelClass(line) {
     if (/error|fatal|fail/i.test(line)) return 'text-error';
@@ -53,35 +75,83 @@ function createLogViewer(rootEl, config) {
     return '';
   }
 
+  function matchesLevel(line) {
+    if (levelFilter === 'all') return true;
+    if (levelFilter === 'error') return /error|fatal|fail/i.test(line);
+    if (levelFilter === 'warn') return /warn/i.test(line);
+    return true;
+  }
+
+  function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+  /* 한 줄을 텍스트 노드 + 하이라이트 <mark>로 쪼개 span에 담는다 (XSS 없이 안전) */
+  function appendLine(text, cls) {
+    var span = document.createElement('span');
+    if (cls) span.className = cls;
+    if (query) {
+      var re = new RegExp('(' + escapeRe(query) + ')', 'ig');
+      var parts = text.split(re);
+      parts.forEach(function (part, i) {
+        if (i % 2 === 1) {
+          var mark = document.createElement('mark');
+          mark.className = 'bg-warning text-warning-content rounded px-0.5';
+          mark.textContent = part;
+          span.appendChild(mark);
+        } else if (part) {
+          span.appendChild(document.createTextNode(part));
+        }
+      });
+      span.appendChild(document.createTextNode('\n'));
+    } else {
+      span.textContent = text + '\n';
+    }
+    viewEl.appendChild(span);
+  }
+
+  /* lastLogs를 현재 검색/레벨 필터로 렌더 (네트워크 요청 없음) */
+  function render() {
+    if (lastMeta === false) {
+      metaEl.textContent = '';
+      countEl.textContent = '';
+      return;
+    }
+    var atBottom = viewEl.scrollHeight - viewEl.scrollTop - viewEl.clientHeight < 40;
+    var q = query.toLowerCase();
+    viewEl.textContent = '';
+    var shown = 0;
+    lastLogs.forEach(function (line) {
+      var text = config.formatLine ? config.formatLine(line, currentSource) : line;
+      if (!matchesLevel(text)) return;
+      if (q && text.toLowerCase().indexOf(q) === -1) return;
+      appendLine(text, levelClass(text));
+      shown++;
+    });
+    if (!shown) {
+      viewEl.textContent = (query || levelFilter !== 'all') ? '(필터에 맞는 로그 없음)' : '(로그 없음)';
+    }
+    countEl.textContent = lastLogs.length ? (shown + ' / ' + lastLogs.length + ' 줄') : '';
+    if (atBottom) viewEl.scrollTop = viewEl.scrollHeight;
+  }
+
   async function refresh() {
     var data;
     try {
       data = await config.fetchLogs(currentSource, lines);
     } catch (e) { return; /* 401은 apiFetch가 modal 처리 */ }
-    var atBottom = viewEl.scrollHeight - viewEl.scrollTop - viewEl.clientHeight < 40;
     if (data.exists === false) {
+      lastMeta = false;
+      lastLogs = [];
       metaEl.textContent = '';
+      countEl.textContent = '';
       viewEl.textContent = '로그 파일이 아직 없습니다: ' + (data.log_file || '(경로 미상)');
       return;
     }
+    lastMeta = data;
+    lastLogs = data.logs || [];
     metaEl.textContent = data.log_file
       ? data.log_file + ' (' + ((data.size_bytes || 0) / 1024 / 1024).toFixed(1) + ' MB)'
       : '';
-    var logs = data.logs || [];
-    viewEl.textContent = '';
-    if (!logs.length) {
-      viewEl.textContent = '(로그 없음)';
-      return;
-    }
-    logs.forEach(function (line) {
-      var span = document.createElement('span');
-      var text = config.formatLine ? config.formatLine(line, currentSource) : line;
-      span.textContent = text + '\n';
-      var cls = levelClass(text);
-      if (cls) span.className = cls;
-      viewEl.appendChild(span);
-    });
-    if (atBottom) viewEl.scrollTop = viewEl.scrollHeight;
+    render();
   }
 
   setInterval(function () {

--- a/suh-ai-server/flask/static/js/palworld.js
+++ b/suh-ai-server/flask/static/js/palworld.js
@@ -366,8 +366,8 @@ function initLogViewer() {
     sources: [
       { id: 'events', label: '이벤트' },
       { id: 'game', label: '게임 로그' },
-      { id: 'stdout', label: 'stdout' },
-      { id: 'stderr', label: 'stderr' },
+      { id: 'stderr', label: '오류(stderr)' },
+      { id: 'flask', label: '시스템(Flask)' },
     ],
     fetchLogs: async function (source, lines) {
       const resp = await apiFetch(API + '/logs?source=' + source + '&lines=' + lines);

--- a/suh-ai-server/flask/test/test_palworld_service.py
+++ b/suh-ai-server/flask/test/test_palworld_service.py
@@ -160,6 +160,14 @@ def test_tail_logs_unknown_source_raises(service):
         service.tail_logs('nope', 100)
 
 
+def test_log_sources_game_points_at_real_stdout_capture():
+    # Palworld는 Pal.log를 만들지 않으므로 game=stdout 캡처를 가리켜야 한다.
+    from config.palworld_config import LOG_SOURCES
+    assert LOG_SOURCES['game'] == LOG_SOURCES['stdout']
+    assert LOG_SOURCES['game'].endswith('palserver-stdout.log')
+    assert 'flask' in LOG_SOURCES  # 관리자 시스템 로그 소스
+
+
 def test_tail_logs_missing_file_reports_path(service, tmp_path):
     missing = str(tmp_path / 'Pal.log')
     with patch.dict('service.palworld_service.LOG_SOURCES', {'game': missing}):


### PR DESCRIPTION
## 개요

관리자 로그 뷰어를 실제로 쓸모 있게 만들고, "게임 로그" 탭이 정직하게 실제 로그를 보여주도록 정비한다.

- https://github.com/Cassiiopeia/suh-project-control/issues/62

## 변경 사항

### 게임 로그 정직화
- Palworld 데디(Pocket Pair 빌드)는 UE 파일 로그를 꺼서 배포 → `Pal.log`는 생성되지 않음(라이브 검증·공식/커뮤니티 문서 확인). 엔진 출력은 stdout으로만 나가고 NSSM이 캡처 중.
- 따라서 `game` 로그 소스를 **실제 stdout 캡처 파일로 매핑**. "게임 로그" 탭이 이제 진짜 서버 콘솔 로그를 보여준다(없음 표시 X).

### 로그 뷰어 강화 (공용 모듈 — Flask 로그 페이지에도 자동 반영)
- 검색어 입력 + 매칭 하이라이트(`<mark>`, XSS 없이 텍스트 노드 분할)
- 레벨 필터(전체/에러/경고)
- 필터는 네트워크 재요청 없이 마지막 로그를 즉시 재렌더, 표시/전체 줄 수 카운트
- 로그 탭 재정비: 이벤트 / 게임 로그 / 오류(stderr) / 시스템(Flask)

### 시스템 로그
- `flask` 로그 소스 추가 — 관리자 서버(Flask) 자체 로그 조회

## 테스트
- game=stdout 캡처 매핑 + flask 소스 존재 검증 추가, flask 전체 72건 통과
