### PR TITLE
정적 자산 캐시 버스팅·월드정보 카드 UI·게임 로그 REST 잡음 필터

### DIFF
--- a/suh-ai-server/flask/router/admin_router.py
+++ b/suh-ai-server/flask/router/admin_router.py
@@ -2,9 +2,27 @@
 Admin pages router - DaisyUI 관리자 페이지 렌더링
 root: 페이지 깊이에 따른 상대경로 프리픽스 (nginx 프리픽스 뒤에서도 동작)
 """
+import os
+
 from flask import Blueprint, render_template
 
 admin_bp = Blueprint('admin', __name__)
+
+# 정적 자산 캐시 버스팅: 템플릿에서 {{ asset('js/palworld.js') }} → 파일 수정시각 토큰.
+# <script src="...palworld.js?v={{ asset('js/palworld.js') }}"> 처럼 써서, 배포로 파일이
+# 바뀌면 URL이 달라져 브라우저가 새 파일을 받는다(하드리로드 불필요).
+# 블루프린트에 붙여 이 페이지들을 서빙하는 어떤 앱에서도 asset()이 정의되게 한다.
+_STATIC_ROOT = os.path.join(os.path.dirname(__file__), '..', 'static')
+
+
+@admin_bp.app_context_processor
+def _inject_asset_helper():
+    def asset(rel_path):
+        try:
+            return str(int(os.path.getmtime(os.path.join(_STATIC_ROOT, rel_path))))
+        except OSError:
+            return '0'
+    return {'asset': asset}
 
 
 @admin_bp.route('/admin', methods=['GET'])

--- a/suh-ai-server/flask/router/palworld_router.py
+++ b/suh-ai-server/flask/router/palworld_router.py
@@ -112,7 +112,8 @@ def logs():
         return jsonify({'error': 'lines must be an integer'}), 400
     try:
         source = request.args.get('source', 'game')
-        return jsonify(palworld_service.tail_logs(source, lines)), 200
+        hide_noise = request.args.get('hide_noise', 'false').lower() in ('1', 'true', 'yes')
+        return jsonify(palworld_service.tail_logs(source, lines, hide_noise)), 200
     except ValueError as e:
         return jsonify({'error': str(e)}), 400
     except Exception as e:

--- a/suh-ai-server/flask/service/palworld_service.py
+++ b/suh-ai-server/flask/service/palworld_service.py
@@ -200,9 +200,13 @@ class PalworldService:
 
     # --- 로그 ---
 
-    TAIL_READ_BYTES = 256 * 1024  # 파일 끝에서 이만큼만 읽는다 (Pal.log는 수십 MB까지 자람)
+    TAIL_READ_BYTES = 256 * 1024        # 일반 tail: 파일 끝에서 이만큼만 읽는다
+    # 잡음 숨김 tail: 실제 이벤트가 REST 잡음에 파묻혀 있어 훨씬 넓게 훑어야 한다.
+    NOISE_TAIL_READ_BYTES = 8 * 1024 * 1024
+    # 우리 폴러가 REST API를 주기 호출하며 남기는 잡음 (게임 로그의 99% 이상 차지)
+    NOISE_MARKER = 'REST accessed endpoint'
 
-    def tail_logs(self, source: str = 'game', lines: int = 200) -> dict:
+    def tail_logs(self, source: str = 'game', lines: int = 200, hide_noise: bool = False) -> dict:
         if source not in LOG_SOURCES:
             raise ValueError(f'Unknown log source: {source}')
         lines = min(int(lines), 500)
@@ -213,12 +217,15 @@ class PalworldService:
         size = os.path.getsize(path)
         result['exists'] = True
         result['size_bytes'] = size
+        read_bytes = self.NOISE_TAIL_READ_BYTES if hide_noise else self.TAIL_READ_BYTES
         with open(path, 'rb') as f:
-            f.seek(max(0, size - self.TAIL_READ_BYTES))
+            f.seek(max(0, size - read_bytes))
             data = f.read()
         all_lines = data.decode('utf-8', errors='replace').splitlines()
-        if size > self.TAIL_READ_BYTES and all_lines:
+        if size > read_bytes and all_lines:
             all_lines = all_lines[1:]  # seek 지점의 첫 줄은 중간에서 잘렸을 수 있다
+        if hide_noise:
+            all_lines = [ln for ln in all_lines if self.NOISE_MARKER not in ln]
         result['logs'] = all_lines[-lines:]
         return result
 

--- a/suh-ai-server/flask/static/js/log-viewer.js
+++ b/suh-ai-server/flask/static/js/log-viewer.js
@@ -7,8 +7,11 @@ function createLogViewer(rootEl, config) {
   var lines = 200;
   var query = '';
   var levelFilter = 'all';   // all | error | warn
+  var hideNoise = true;      // REST 폴링 잡음 등 반복 라인 숨기기 (기본 ON)
   var lastLogs = [];         // 마지막으로 받은 원본 로그 (필터 변경 시 재요청 없이 재렌더)
   var lastMeta = null;
+  // 잡음 패턴: 우리 폴러가 만드는 REST 접근 로그 등. config로 덮어쓸 수 있다.
+  var noiseRe = config.noisePattern || /REST accessed endpoint/i;
 
   rootEl.innerHTML =
     '<div class="flex flex-wrap items-center gap-2 mb-3">' +
@@ -23,6 +26,9 @@ function createLogViewer(rootEl, config) {
     '<select class="select select-sm w-28" data-role="lines">' +
     '<option value="100">100줄</option><option value="200" selected>200줄</option><option value="500">500줄</option>' +
     '</select>' +
+    '<label class="label cursor-pointer gap-2 text-sm" data-role="noise-wrap">' +
+    '<input type="checkbox" class="toggle toggle-sm toggle-primary" data-role="noise" checked><span>잡음 숨기기</span>' +
+    '</label>' +
     '<label class="label cursor-pointer gap-2 text-sm">' +
     '<input type="checkbox" class="toggle toggle-sm toggle-primary" data-role="auto" checked><span>자동 새로고침</span>' +
     '</label>' +
@@ -67,6 +73,9 @@ function createLogViewer(rootEl, config) {
   });
   rootEl.querySelector('[data-role="level"]').addEventListener('change', function (e) {
     levelFilter = e.target.value; render();
+  });
+  rootEl.querySelector('[data-role="noise"]').addEventListener('change', function (e) {
+    hideNoise = e.target.checked; refresh();  // 서버측 필터 창이 달라져 재요청 필요
   });
 
   function levelClass(line) {
@@ -121,6 +130,7 @@ function createLogViewer(rootEl, config) {
     var shown = 0;
     lastLogs.forEach(function (line) {
       var text = config.formatLine ? config.formatLine(line, currentSource) : line;
+      if (hideNoise && noiseRe.test(text)) return;
       if (!matchesLevel(text)) return;
       if (q && text.toLowerCase().indexOf(q) === -1) return;
       appendLine(text, levelClass(text));
@@ -136,7 +146,7 @@ function createLogViewer(rootEl, config) {
   async function refresh() {
     var data;
     try {
-      data = await config.fetchLogs(currentSource, lines);
+      data = await config.fetchLogs(currentSource, lines, hideNoise);
     } catch (e) { return; /* 401은 apiFetch가 modal 처리 */ }
     if (data.exists === false) {
       lastMeta = false;

--- a/suh-ai-server/flask/static/js/palworld.js
+++ b/suh-ai-server/flask/static/js/palworld.js
@@ -116,16 +116,18 @@ function renderWorldInfo(data) {
   const box = document.getElementById('world-info');
   if (!box) return;
   if (!data.rest_available) {
-    box.innerHTML = '<div class="opacity-60">서버 정지 중 — 정보를 불러올 수 없습니다.</div>';
+    box.innerHTML = '<div class="opacity-60 col-span-full">서버 정지 중 — 정보를 불러올 수 없습니다.</div>';
     return;
   }
+  // 각 항목을 라벨(위, 작고 흐리게) + 값(아래) 스택 블록으로. 절대 옆 칸과 겹치지 않고 어느 폭에서도 깔끔.
   box.innerHTML = WORLD_INFO_ROWS.map(row => {
     let v = row.get(data);
     if (v == null || v === '') v = '-';
     else if (row.suffix) v = v + row.suffix;
-    return '<div class="flex justify-between gap-3 border-b border-base-200 py-1">' +
-      '<span class="opacity-60 shrink-0">' + escapeHtml(row.label) + '</span>' +
-      '<span class="text-right ' + (row.mono ? 'font-mono text-xs break-all' : '') + '">' + escapeHtml(v) + '</span></div>';
+    return '<div class="bg-base-200/50 rounded-lg px-3 py-2 min-w-0">' +
+      '<div class="text-[11px] uppercase tracking-wide opacity-50 mb-0.5">' + escapeHtml(row.label) + '</div>' +
+      '<div class="min-w-0 break-words ' + (row.mono ? 'font-mono text-xs' : 'font-medium') + '">' + escapeHtml(v) + '</div>' +
+      '</div>';
   }).join('');
 }
 
@@ -369,8 +371,9 @@ function initLogViewer() {
       { id: 'stderr', label: '오류(stderr)' },
       { id: 'flask', label: '시스템(Flask)' },
     ],
-    fetchLogs: async function (source, lines) {
-      const resp = await apiFetch(API + '/logs?source=' + source + '&lines=' + lines);
+    fetchLogs: async function (source, lines, hideNoise) {
+      const noise = hideNoise ? '&hide_noise=true' : '';
+      const resp = await apiFetch(API + '/logs?source=' + source + '&lines=' + lines + noise);
       return resp.json();
     },
     formatLine: function (line, source) {

--- a/suh-ai-server/flask/templates/admin/base.html
+++ b/suh-ai-server/flask/templates/admin/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}SUH AI Server Admin{% endblock %}</title>
-  <link rel="stylesheet" href="{{ root }}/static/css/app.css">
+  <link rel="stylesheet" href="{{ root }}/static/css/app.css?v={{ asset('css/app.css') }}">
   <script>
     /* FOUC 방지 - CSS보다 먼저 저장된 테마 적용 */
     (function () {
@@ -97,8 +97,8 @@
 </dialog>
 <div id="toast-container" class="toast toast-end z-50"></div>
 
-<script src="{{ root }}/static/js/vendor/lucide.min.js"></script>
-<script src="{{ root }}/static/js/admin-common.js"></script>
+<script src="{{ root }}/static/js/vendor/lucide.min.js?v={{ asset('js/vendor/lucide.min.js') }}"></script>
+<script src="{{ root }}/static/js/admin-common.js?v={{ asset('js/admin-common.js') }}"></script>
 <script>
   lucide.createIcons();
   (function () {

--- a/suh-ai-server/flask/templates/admin/logs.html
+++ b/suh-ai-server/flask/templates/admin/logs.html
@@ -21,7 +21,7 @@
 </div>
 {% endblock %}
 {% block extra_js %}
-<script src="{{ root }}/static/js/log-viewer.js"></script>
+<script src="{{ root }}/static/js/log-viewer.js?v={{ asset('js/log-viewer.js') }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const viewer = createLogViewer(document.getElementById('flask-log-viewer'), {

--- a/suh-ai-server/flask/templates/admin/palworld.html
+++ b/suh-ai-server/flask/templates/admin/palworld.html
@@ -91,8 +91,8 @@
       <h2 class="card-title text-base">
         <i data-lucide="globe" class="size-5"></i>월드 · 서버 정보
       </h2>
-      <div id="world-info" class="grid gap-x-6 gap-y-2 sm:grid-cols-2 text-sm">
-        <div class="opacity-60">불러오는 중…</div>
+      <div id="world-info" class="grid gap-2 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 text-sm">
+        <div class="opacity-60 col-span-full">불러오는 중…</div>
       </div>
     </div>
   </div>
@@ -206,6 +206,6 @@
 </dialog>
 {% endblock %}
 {% block extra_js %}
-<script src="{{ root }}/static/js/log-viewer.js"></script>
-<script src="{{ root }}/static/js/palworld.js"></script>
+<script src="{{ root }}/static/js/log-viewer.js?v={{ asset('js/log-viewer.js') }}"></script>
+<script src="{{ root }}/static/js/palworld.js?v={{ asset('js/palworld.js') }}"></script>
 {% endblock %}

--- a/suh-ai-server/flask/test/test_palworld_router.py
+++ b/suh-ai-server/flask/test/test_palworld_router.py
@@ -71,7 +71,7 @@ def test_logs_passes_source_and_lines(client):
         resp = client.get('/palworld/logs?source=events&lines=100')
     assert resp.status_code == 200
     assert resp.get_json()['logs'] == ['a']
-    mock_tail.assert_called_once_with('events', 100)
+    mock_tail.assert_called_once_with('events', 100, False)
 
 
 def test_logs_defaults_to_game_source(client):
@@ -79,7 +79,14 @@ def test_logs_defaults_to_game_source(client):
     with patch('router.palworld_router.palworld_service.tail_logs', return_value=fake) as mock_tail:
         resp = client.get('/palworld/logs')
     assert resp.status_code == 200
-    mock_tail.assert_called_once_with('game', 200)
+    mock_tail.assert_called_once_with('game', 200, False)
+
+
+def test_logs_passes_hide_noise_flag(client):
+    fake = {'source': 'game', 'log_file': 'x', 'exists': True, 'size_bytes': 1, 'logs': []}
+    with patch('router.palworld_router.palworld_service.tail_logs', return_value=fake) as mock_tail:
+        client.get('/palworld/logs?source=game&lines=200&hide_noise=true')
+    mock_tail.assert_called_once_with('game', 200, True)
 
 
 def test_guide_returns_info(client):

--- a/suh-ai-server/flask/test/test_palworld_service.py
+++ b/suh-ai-server/flask/test/test_palworld_service.py
@@ -189,6 +189,29 @@ def test_tail_logs_returns_last_lines(service, tmp_path):
     assert result['size_bytes'] == log.stat().st_size
 
 
+def test_tail_logs_hide_noise_filters_rest_lines(service, tmp_path):
+    log = tmp_path / 'stdout.log'
+    body = []
+    for i in range(50):
+        body.append(f'[LOG] REST accessed endpoint /v1/api/players OK {i}')
+    body.insert(10, '[LOG] 재석 connected the server. (User id: steam_1)')
+    body.insert(30, '[LOG] 로리매킬로이 left the server.')
+    log.write_text('\n'.join(body) + '\n', encoding='utf-8')
+    with patch.dict('service.palworld_service.LOG_SOURCES', {'game': str(log)}):
+        result = service.tail_logs('game', 200, hide_noise=True)
+    assert all('REST accessed endpoint' not in ln for ln in result['logs'])
+    assert any('connected the server' in ln for ln in result['logs'])
+    assert any('left the server' in ln for ln in result['logs'])
+
+
+def test_tail_logs_without_hide_noise_keeps_all(service, tmp_path):
+    log = tmp_path / 'stdout.log'
+    log.write_text('[LOG] REST accessed endpoint OK\n[LOG] real event\n', encoding='utf-8')
+    with patch.dict('service.palworld_service.LOG_SOURCES', {'game': str(log)}):
+        result = service.tail_logs('game', 200, hide_noise=False)
+    assert len(result['logs']) == 2
+
+
 def test_tail_logs_reads_only_tail_of_large_file(service, tmp_path):
     # 60000줄 x 11바이트 ≈ 660KB > TAIL_READ_BYTES(256KB) — seek 경로 검증
     log = tmp_path / 'Pal.log'


### PR DESCRIPTION
## 개요

대시보드 확충 배포 후 발견된 3가지 문제 수정.

- https://github.com/Cassiiopeia/suh-project-control/issues/65

## 변경 사항

### 1. 정적 자산 캐시 버스팅 (하드 리로드 문제 해결)
- `admin_bp.app_context_processor`로 `asset()` 헬퍼 제공 → JS/CSS URL에 `?v=<파일 수정시각>` 부여
- 배포로 파일이 바뀌면 URL이 달라져 브라우저가 자동으로 새 파일을 받음 (하드 리로드 불필요)
- 블루프린트에 붙여 이 페이지를 서빙하는 어떤 앱에서도 동작

### 2. 월드·서버 정보 카드 재설계
- 라벨(위, 작게)+값(아래) 스택 블록으로 변경, 반응형 2~4열 그리드
- 이전 2열에서 라벨·값이 붙어 뭉개지던 문제 제거

### 3. 게임 로그 REST 잡음 필터
- 게임 로그 stdout이 우리 폴러의 `REST accessed endpoint OK`로 99% 이상 채워져 실제 이벤트가 안 보였음
- 로그 뷰어에 "잡음 숨기기" 토글(기본 ON) + 서버측 `hide_noise` 필터
- game/stdout는 8MB 넓은 창을 훑어 잡음 제거 → 접속/퇴장/서버 기동 등 실제 이벤트 노출

## 테스트
- 잡음 필터·라우터 파라미터 테스트 추가/갱신, flask 전체 75건 통과
