### PR TITLE
월드정보 카드 UI 재조정 및 로그 잡음 빈줄 제거

### DIFF
--- a/suh-ai-server/flask/service/palworld_service.py
+++ b/suh-ai-server/flask/service/palworld_service.py
@@ -225,7 +225,10 @@ class PalworldService:
         if size > read_bytes and all_lines:
             all_lines = all_lines[1:]  # seek 지점의 첫 줄은 중간에서 잘렸을 수 있다
         if hide_noise:
-            all_lines = [ln for ln in all_lines if self.NOISE_MARKER not in ln]
+            # REST 폴링 잡음 + 빈 줄(stdout이 줄마다 공백행을 끼워 넣음)을 함께 제거해
+            # 실제 이벤트만 남긴다.
+            all_lines = [ln for ln in all_lines
+                         if ln.strip() and self.NOISE_MARKER not in ln]
         result['logs'] = all_lines[-lines:]
         return result
 

--- a/suh-ai-server/flask/static/js/palworld.js
+++ b/suh-ai-server/flask/static/js/palworld.js
@@ -119,14 +119,15 @@ function renderWorldInfo(data) {
     box.innerHTML = '<div class="opacity-60 col-span-full">서버 정지 중 — 정보를 불러올 수 없습니다.</div>';
     return;
   }
-  // 각 항목을 라벨(위, 작고 흐리게) + 값(아래) 스택 블록으로. 절대 옆 칸과 겹치지 않고 어느 폭에서도 깔끔.
+  // 라벨(고정폭, 좌측 muted) + 값(바로 옆 좌측정렬) 한 줄 key-value.
+  // justify-between으로 양끝에 붙이지 않으므로 옆 칸 라벨과 겹치지 않는다.
   box.innerHTML = WORLD_INFO_ROWS.map(row => {
     let v = row.get(data);
     if (v == null || v === '') v = '-';
     else if (row.suffix) v = v + row.suffix;
-    return '<div class="bg-base-200/50 rounded-lg px-3 py-2 min-w-0">' +
-      '<div class="text-[11px] uppercase tracking-wide opacity-50 mb-0.5">' + escapeHtml(row.label) + '</div>' +
-      '<div class="min-w-0 break-words ' + (row.mono ? 'font-mono text-xs' : 'font-medium') + '">' + escapeHtml(v) + '</div>' +
+    return '<div class="flex items-baseline gap-3 py-1.5 px-2 rounded odd:bg-base-200/40 min-w-0">' +
+      '<span class="opacity-50 w-20 shrink-0">' + escapeHtml(row.label) + '</span>' +
+      '<span class="min-w-0 break-words font-medium ' + (row.mono ? 'font-mono text-xs' : '') + '">' + escapeHtml(v) + '</span>' +
       '</div>';
   }).join('');
 }

--- a/suh-ai-server/flask/templates/admin/palworld.html
+++ b/suh-ai-server/flask/templates/admin/palworld.html
@@ -91,7 +91,7 @@
       <h2 class="card-title text-base">
         <i data-lucide="globe" class="size-5"></i>월드 · 서버 정보
       </h2>
-      <div id="world-info" class="grid gap-2 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 text-sm">
+      <div id="world-info" class="grid gap-x-8 gap-y-0.5 sm:grid-cols-2 text-sm">
         <div class="opacity-60 col-span-full">불러오는 중…</div>
       </div>
     </div>

--- a/suh-ai-server/flask/test/test_palworld_service.py
+++ b/suh-ai-server/flask/test/test_palworld_service.py
@@ -189,17 +189,20 @@ def test_tail_logs_returns_last_lines(service, tmp_path):
     assert result['size_bytes'] == log.stat().st_size
 
 
-def test_tail_logs_hide_noise_filters_rest_lines(service, tmp_path):
+def test_tail_logs_hide_noise_filters_rest_and_blank_lines(service, tmp_path):
     log = tmp_path / 'stdout.log'
     body = []
     for i in range(50):
+        # 실제 stdout처럼 각 REST 줄 사이에 빈 줄이 낀 형태
         body.append(f'[LOG] REST accessed endpoint /v1/api/players OK {i}')
+        body.append('')
     body.insert(10, '[LOG] 재석 connected the server. (User id: steam_1)')
     body.insert(30, '[LOG] 로리매킬로이 left the server.')
     log.write_text('\n'.join(body) + '\n', encoding='utf-8')
     with patch.dict('service.palworld_service.LOG_SOURCES', {'game': str(log)}):
         result = service.tail_logs('game', 200, hide_noise=True)
     assert all('REST accessed endpoint' not in ln for ln in result['logs'])
+    assert all(ln.strip() for ln in result['logs'])  # 빈 줄도 제거
     assert any('connected the server' in ln for ln in result['logs'])
     assert any('left the server' in ln for ln in result['logs'])
 


### PR DESCRIPTION
## 개요

#65 후속 조정.

- https://github.com/Cassiiopeia/suh-project-control/issues/65

## 변경
- 월드·서버 정보 카드: 세로 스택 → 가로 라벨(고정폭)+값 한 줄 key-value, 2열 넓은 gap+zebra. 겹침 제거·그룹감 유지.
- 게임 로그 잡음 필터가 stdout 빈 줄까지 제거해 실제 접속/퇴장 이벤트만 노출.
- flask 75건 통과.
