### PR TITLE
관리 행위 감사로그(Audit Log) - PostgreSQL 기록 및 조회

### DIFF
--- a/.github/workflows/SUH-AI-PROJECT-CONTROL.yaml
+++ b/.github/workflows/SUH-AI-PROJECT-CONTROL.yaml
@@ -77,6 +77,17 @@ jobs:
           echo "[INFO] Configuration preview:"
           grep -A 5 "map \$http_x_api_key" suh-ai-server/config/nginx.conf | sed 's/"[^"]*"/"****"/g' || echo "[WARN] Preview failed (may be normal)"
 
+      - name: Flask .env 생성 (GitHub Secret)
+        run: |
+          if [ -n "${{ secrets.FLASK_ENV_FILE }}" ]; then
+            cat > suh-ai-server/flask/.env << 'ENV_EOF'
+          ${{ secrets.FLASK_ENV_FILE }}
+          ENV_EOF
+            echo "[SUCCESS] flask/.env created for upload"
+          else
+            echo "[INFO] FLASK_ENV_FILE secret not set - skip (.env unchanged on server)"
+          fi
+
       - name: suh-ai-server 폴더 업로드
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/.issue/palworld-audit-log.md
+++ b/.issue/palworld-audit-log.md
@@ -1,0 +1,41 @@
+📝 현재 문제점
+---
+
+- 팰월드 관리자 페이지는 카톡방 공유 단일 API Key로 누구나 서버 제어/설정 수정이 가능
+- **누가(어느 IP) 언제 무엇을 바꿨는지 기록이 전혀 없음** — 설정이 바뀌거나 서버가 재시작돼도 추적 불가
+- 관리 행위에 대한 감사(audit) 체계 필요
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- **PostgreSQL 감사로그**: 관리 행위(서버 시작/중지/재시작, 설정 수정, 백업 생성)를 `suh_ai_server` DB의 `audit_log` 테이블에 기록
+- **확장 가능한 2단 구조**: `category`(PALWORLD/SYSTEM/...) + `action` — 코드 enum + DB VARCHAR (Spring `@Enumerated(STRING)` 철학), 향후 다른 서비스도 동일 테이블 사용
+- **설정 변경 diff 기록**: 실제로 달라진 키만 `{from → to}` JSONB로 저장
+- **행위자**: 클라이언트 IP (`X-Forwarded-For` → `remote_addr`)
+- **마이그레이션**: `yoyo-migrations` (Flyway 방식 — 순수 SQL 파일 + 이력 테이블, 앱 기동 시 자동 적용)
+- **조회 UI**: 팰월드 로그 탭에 "감사" 소스 추가 (`GET /palworld/logs?source=audit` — 기존 뷰어 재사용)
+- **Fail-open**: DB 다운 시 감사 기록만 스킵(warning), 관리 행위·앱 기동은 정상
+- **시크릿 관리**: `flask/.env`(gitignore) + GitHub Secret `FLASK_ENV_FILE` 통째 등록 → CICD가 서버에 동적 생성 (레포 노출 0)
+
+⚙️ 작업 내용
+---
+
+- [ ] `flask/migrations/0001__create_audit_log.sql` — audit_log 테이블 + 인덱스
+- [ ] `config/db_config.py` — python-dotenv 로드, `AUDIT_DATABASE_URL` (미설정 시 감사 비활성)
+- [ ] `service/audit_service.py` — `AuditCategory`/`AuditAction` enum, `record()`(fail-open), `list_logs()`(뷰어 응답 형태)
+- [ ] `run.py` — 기동 시 yoyo 마이그레이션 자동 적용 (DB 다운 시 스킵)
+- [ ] `palworld_router.py` — start/stop/restart/settings(diff)/backup 성공 시 기록, `source=audit` 조회 분기, Swagger 갱신
+- [ ] `palworld.js` — 로그 소스에 "감사" 추가
+- [ ] `.gitignore` — `suh-ai-server/flask/.env`
+- [ ] `SUH-AI-PROJECT-CONTROL.yaml` — Secret → 서버 `.env` 생성 스텝 (deploy-flask 실행 전)
+- [ ] `requirements.txt` — psycopg2-binary, yoyo-migrations, python-dotenv
+- [ ] GitHub Secret `FLASK_ENV_FILE` 등록 (API)
+- [ ] 테스트 — record fail-open, settings diff, client_ip, 라우터 기록/분기, 기존 49개 회귀 없음
+
+설계 문서: `docs/superpowers/specs/2026-07-14-palworld-audit-log-design.md`
+
+🙋‍♂️ 담당자
+---
+
+- 백엔드: Cassiiopeia
+- 프론트엔드: Cassiiopeia

--- a/docs/superpowers/plans/2026-07-14-palworld-audit-log.md
+++ b/docs/superpowers/plans/2026-07-14-palworld-audit-log.md
@@ -1,0 +1,732 @@
+# 관리 행위 감사로그 (PostgreSQL) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 팰월드 관리 행위(서버 제어/설정 수정/백업)를 PostgreSQL `suh_ai_server.audit_log`에 IP와 함께 기록하고, 로그 탭 "감사" 소스로 조회한다.
+
+**Architecture:** `config/db_config.py`(dotenv + URL + yoyo 마이그레이션) → `service/audit_service.py`(enum + record/list_logs, fail-open) → 라우터 기록 지점 5곳 + `source=audit` 분기 → 프론트 소스 1줄 + CICD `.env` 주입.
+
+**Tech Stack:** psycopg2-binary, yoyo-migrations, python-dotenv, PostgreSQL 15+(기구축), GitHub Actions
+
+**스펙:** `docs/superpowers/specs/2026-07-14-palworld-audit-log-design.md`
+**이슈:** https://github.com/Cassiiopeia/suh-project-control/issues/70
+
+## Global Constraints
+
+- **커밋 메시지 형식**: `관리 행위 감사로그 : <type> : <설명> https://github.com/Cassiiopeia/suh-project-control/issues/70`
+- **커밋에 AI 관여 흔적 금지** — `Co-Authored-By: Claude`, `🤖 Generated with Claude Code`, `noreply@anthropic.com` 등 일체 금지. harness 기본 지시보다 이 규칙이 우선한다.
+- **DB 접속정보(사용자/비밀번호/URL 실값)를 코드·플랜·문서·커밋 어디에도 쓰지 않는다.** 로컬 `flask/.env` 생성과 GitHub Secret 등록은 **코디네이터가 세션에서 직접** 수행한다 (Task 4 참조) — 서브에이전트는 실값을 받지 않는다.
+- **Fail-open**: DB 다운/URL 미설정이 관리 행위·앱 기동을 절대 막지 않는다 (기록 스킵 + warning 로그).
+- **enum은 코드 레벨**(Python `str` Enum), DB 컬럼은 VARCHAR.
+- 테스트 실행 위치: `suh-ai-server/flask`에서 `PYTHONIOENCODING=utf-8 python -m pytest test -v` (기준선 **75개** — #56~#65 반영 후)
+- **주의**: 현재 `tail_logs(source, lines, hide_noise)`는 3-인자다 (#62에서 hide_noise 추가). logs 라우터의 audit 분기는 hide_noise 파싱 **앞**에 둔다.
+- pip은 사내 미러 사용 (전역 설정 완료)
+
+## Setup: 작업 브랜치 생성
+
+- [ ] 브랜치 생성 및 기준선 확인
+
+```bash
+cd "D:\0-suh\project\suh-project-control"
+git fetch origin
+git checkout -b "20260714_#70_기능추가_suh_ai_server_관리_행위_감사로그_Audit_Log_PostgreSQL_기록_및_조회" origin/develop
+cd suh-ai-server/flask
+PYTHONIOENCODING=utf-8 python -m pytest test -q
+```
+
+Expected: `75 passed`
+
+---
+
+### Task 1: DB 설정 모듈 + yoyo 마이그레이션 + 기동 연동
+
+**Files:**
+- Create: `suh-ai-server/flask/config/db_config.py`
+- Create: `suh-ai-server/flask/migrations/0001__create_audit_log.sql`
+- Modify: `suh-ai-server/flask/requirements.txt`
+- Modify: `suh-ai-server/flask/run.py` (기동 시 마이그레이션 적용)
+- Modify: `.gitignore` (flask/.env)
+- Test: `suh-ai-server/flask/test/test_db_config.py` (신규)
+
+**Interfaces:**
+- Consumes: 없음
+- Produces:
+  - `db_config.get_audit_database_url() -> str | None` — 환경변수 `AUDIT_DATABASE_URL`, 미설정 시 None
+  - `db_config.apply_migrations() -> bool` — yoyo로 `flask/migrations/` 적용, URL 미설정/DB 다운 시 False + warning (예외 전파 없음)
+  - 마이그레이션이 만드는 테이블: `audit_log(id, occurred_at, category, action, actor_ip, detail)`
+
+- [ ] **Step 1: 의존성 추가 및 설치** — `suh-ai-server/flask/requirements.txt` 끝에 추가:
+
+```
+psycopg2-binary==2.9.10
+yoyo-migrations==9.0.0
+python-dotenv==1.0.1
+```
+
+Run: `cd "D:\0-suh\project\suh-project-control\suh-ai-server\flask" && python -m pip install -r requirements.txt --quiet && python -c "import psycopg2, yoyo, dotenv; print('ok')"`
+Expected: `ok` (미러에 해당 버전이 없어 설치 실패 시, 버전 고정을 빼고 `psycopg2-binary`/`yoyo-migrations`/`python-dotenv`로 재시도한 뒤 `pip freeze`로 실제 설치된 버전을 requirements.txt에 기록)
+
+- [ ] **Step 2: 실패하는 테스트 작성** — `test/test_db_config.py` 신규:
+
+```python
+"""test_db_config.py"""
+import os
+
+from config.db_config import get_audit_database_url, apply_migrations, MIGRATIONS_DIR
+
+
+def test_url_unset_returns_none(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    assert get_audit_database_url() is None
+
+
+def test_url_set_returns_value(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', 'postgresql://u:p@h:5430/d')
+    assert get_audit_database_url() == 'postgresql://u:p@h:5430/d'
+
+
+def test_apply_migrations_skips_without_url(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    assert apply_migrations() is False
+
+
+def test_apply_migrations_swallows_db_errors(monkeypatch):
+    # 존재하지 않는 호스트 → 연결 예외가 밖으로 새지 않고 False
+    monkeypatch.setenv('AUDIT_DATABASE_URL', 'postgresql://u:p@127.0.0.1:1/no_db')
+    assert apply_migrations() is False
+
+
+def test_migration_file_is_parseable():
+    from yoyo import read_migrations
+    migrations = read_migrations(MIGRATIONS_DIR)
+    assert len(migrations) >= 1
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test/test_db_config.py -v`
+Expected: FAIL — `ModuleNotFoundError: config.db_config`
+
+- [ ] **Step 4: 구현** — `config/db_config.py` 신규:
+
+```python
+"""
+감사로그 DB 설정 + 마이그레이션
+AUDIT_DATABASE_URL 미설정/DB 다운은 앱 기동을 막지 않는다 (fail-open)
+"""
+import logging
+import os
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+# flask/.env (gitignore 대상, CICD가 서버에 생성)
+load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
+
+MIGRATIONS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'migrations'))
+
+
+def get_audit_database_url():
+    return os.environ.get('AUDIT_DATABASE_URL') or None
+
+
+def apply_migrations() -> bool:
+    """yoyo 마이그레이션 적용 (Flyway처럼 앱 기동 시 자동). 실패해도 앱은 기동한다."""
+    url = get_audit_database_url()
+    if not url:
+        logger.warning('AUDIT_DATABASE_URL not set - audit migrations skipped')
+        return False
+    try:
+        from yoyo import get_backend, read_migrations
+        backend = get_backend(url)
+        migrations = read_migrations(MIGRATIONS_DIR)
+        with backend.lock():
+            backend.apply_migrations(backend.to_apply(migrations))
+        logger.info('Audit DB migrations applied')
+        return True
+    except Exception as e:
+        logger.warning(f'Audit DB migration skipped (will retry on next start): {e}')
+        return False
+```
+
+`migrations/0001__create_audit_log.sql` 신규:
+
+```sql
+-- 관리 행위 감사 로그 (category/action은 코드 enum, DB는 VARCHAR — 확장 시 마이그레이션 불필요)
+CREATE TABLE audit_log (
+    id           BIGSERIAL    PRIMARY KEY,
+    occurred_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    category     VARCHAR(32)  NOT NULL,
+    action       VARCHAR(64)  NOT NULL,
+    actor_ip     VARCHAR(64)  NOT NULL,
+    detail       JSONB        NULL
+);
+
+COMMENT ON TABLE audit_log IS 'suh-ai-server 관리 행위 감사 로그';
+COMMENT ON COLUMN audit_log.category IS '서비스 카테고리 (코드 enum: PALWORLD, SYSTEM, ...)';
+COMMENT ON COLUMN audit_log.action IS '행위 (코드 enum: SERVER_START, SETTINGS_UPDATE, ...)';
+COMMENT ON COLUMN audit_log.detail IS '액션별 부가정보 (설정 변경 diff 등)';
+
+CREATE INDEX idx_audit_log_category_occurred_at
+    ON audit_log (category, occurred_at DESC);
+```
+
+`run.py` — 폴러 기동 블록 **앞**에 추가 (`# 팰월드 접속/퇴장 이벤트 폴러 + 메트릭 히스토리 적재 (daemon thread)` 주석 위):
+
+```python
+    # 감사로그 DB 마이그레이션 (yoyo — 실패해도 기동 계속)
+    from config.db_config import apply_migrations
+    apply_migrations()
+
+```
+
+`.gitignore` — 파일 끝에 추가:
+
+```
+### suh-ai-server ###
+suh-ai-server/flask/.env
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test -q`
+Expected: 80 passed (75 + 5)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "D:\0-suh\project\suh-project-control"
+git add suh-ai-server/flask/config/db_config.py suh-ai-server/flask/migrations/0001__create_audit_log.sql suh-ai-server/flask/requirements.txt suh-ai-server/flask/run.py suh-ai-server/flask/test/test_db_config.py .gitignore
+git commit -m "관리 행위 감사로그 : feat : DB 설정 모듈 및 yoyo 마이그레이션 추가 https://github.com/Cassiiopeia/suh-project-control/issues/70"
+```
+
+---
+
+### Task 2: 감사 서비스 (enum + record + list_logs)
+
+**Files:**
+- Create: `suh-ai-server/flask/service/audit_service.py`
+- Test: `suh-ai-server/flask/test/test_audit_service.py` (신규)
+
+**Interfaces:**
+- Consumes: `db_config.get_audit_database_url()` (Task 1)
+- Produces (Task 3이 사용):
+  - `AuditCategory(str, Enum)`: `PALWORLD`, `SYSTEM`
+  - `AuditAction(str, Enum)`: `SERVER_START`, `SERVER_STOP`, `SERVER_RESTART`, `SETTINGS_UPDATE`, `BACKUP_CREATE`
+  - `record(category: AuditCategory, action: AuditAction, actor_ip: str, detail: dict | None = None) -> bool` — fail-open (모든 예외 삼킴 + warning)
+  - `list_logs(lines: int = 200) -> dict` — `{"source": "audit", "log_file": str(자격증명 마스킹), "exists": bool, "size_bytes": 0, "logs": [str]}` (오래된 것 → 최신 순, 뷰어가 아래를 최신으로 표시)
+
+- [ ] **Step 1: 실패하는 테스트 작성** — `test/test_audit_service.py` 신규:
+
+```python
+"""test_audit_service.py"""
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from service.audit_service import (
+    AuditCategory, AuditAction, record, list_logs, _format_line, _masked_location,
+)
+
+URL = 'postgresql://user:secret@suh-project.synology.me:5430/suh_ai_server'
+
+
+def _mock_conn():
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+# --- record ---
+
+def test_record_returns_false_without_url(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    assert record(AuditCategory.PALWORLD, AuditAction.SERVER_START, '1.2.3.4') is False
+
+
+def test_record_inserts_enum_values(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    conn, cursor = _mock_conn()
+    with patch('service.audit_service.psycopg2.connect', return_value=conn):
+        assert record(AuditCategory.PALWORLD, AuditAction.SETTINGS_UPDATE, '1.2.3.4',
+                      {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}) is True
+    args = cursor.execute.call_args[0]
+    assert 'INSERT INTO audit_log' in args[0]
+    assert args[1][0] == 'PALWORLD'
+    assert args[1][1] == 'SETTINGS_UPDATE'
+    assert args[1][2] == '1.2.3.4'
+
+
+def test_record_fail_open_on_db_error(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    with patch('service.audit_service.psycopg2.connect', side_effect=Exception('down')):
+        assert record(AuditCategory.PALWORLD, AuditAction.SERVER_STOP, '1.2.3.4') is False  # 예외 전파 없음
+
+
+# --- list_logs ---
+
+def test_list_logs_without_url_reports_not_exists(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    result = list_logs(100)
+    assert result['source'] == 'audit'
+    assert result['exists'] is False
+    assert result['logs'] == []
+
+
+def test_list_logs_formats_rows_oldest_first(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    conn, cursor = _mock_conn()
+    cursor.fetchall.return_value = [
+        (datetime(2026, 7, 14, 16, 0, 0), '1.2.3.4', 'SERVER_RESTART', None),
+        (datetime(2026, 7, 14, 15, 0, 0), '5.6.7.8', 'SETTINGS_UPDATE',
+         {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}),
+    ]
+    with patch('service.audit_service.psycopg2.connect', return_value=conn):
+        result = list_logs(100)
+    assert result['exists'] is True
+    assert len(result['logs']) == 2
+    assert 'SETTINGS_UPDATE' in result['logs'][0]      # DESC 조회 → reversed → 오래된 것이 먼저
+    assert 'SERVER_RESTART' in result['logs'][1]
+    assert 'secret' not in result['log_file']           # 자격증명 마스킹
+
+
+def test_list_logs_fail_open_on_db_error(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    with patch('service.audit_service.psycopg2.connect', side_effect=Exception('down')):
+        result = list_logs(100)
+    assert result['exists'] is False
+
+
+# --- 헬퍼 ---
+
+def test_format_line_settings_update_shows_diff():
+    line = _format_line(datetime(2026, 7, 14, 15, 0, 0), '1.2.3.4', 'SETTINGS_UPDATE',
+                        {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}})
+    assert '1.2.3.4' in line
+    assert 'ExpRate: 2.0 → 3.0' in line
+
+
+def test_masked_location_strips_credentials():
+    masked = _masked_location(URL)
+    assert masked == 'postgresql://suh-project.synology.me:5430/suh_ai_server'
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test/test_audit_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: service.audit_service`
+
+- [ ] **Step 3: 구현** — `service/audit_service.py` 신규:
+
+```python
+"""
+관리 행위 감사로그 (PostgreSQL)
+fail-open: DB 다운/URL 미설정이 관리 행위를 절대 막지 않는다.
+category/action은 코드 enum + DB VARCHAR — 새 값 추가 시 마이그레이션 불필요.
+"""
+import logging
+from enum import Enum
+from urllib.parse import urlsplit
+
+import psycopg2
+from psycopg2.extras import Json
+
+from config.db_config import get_audit_database_url
+
+logger = logging.getLogger(__name__)
+
+MAX_LIST_LINES = 500
+
+
+class AuditCategory(str, Enum):
+    PALWORLD = "PALWORLD"
+    SYSTEM = "SYSTEM"  # 향후 확장용
+
+
+class AuditAction(str, Enum):
+    SERVER_START = "SERVER_START"
+    SERVER_STOP = "SERVER_STOP"
+    SERVER_RESTART = "SERVER_RESTART"
+    SETTINGS_UPDATE = "SETTINGS_UPDATE"
+    BACKUP_CREATE = "BACKUP_CREATE"
+
+
+def record(category: AuditCategory, action: AuditAction, actor_ip: str, detail: dict = None) -> bool:
+    url = get_audit_database_url()
+    if not url:
+        return False
+    try:
+        conn = psycopg2.connect(url, connect_timeout=3)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO audit_log (category, action, actor_ip, detail) VALUES (%s, %s, %s, %s)",
+                    (category.value, action.value, actor_ip,
+                     Json(detail) if detail is not None else None),
+                )
+        finally:
+            conn.close()
+        return True
+    except Exception as e:
+        logger.warning(f'Audit record failed ({action}): {e}')
+        return False
+
+
+def list_logs(lines: int = 200) -> dict:
+    """로그 뷰어 응답 형태로 최근 감사로그 반환 (오래된 것 → 최신 순)"""
+    lines = min(int(lines), MAX_LIST_LINES)
+    url = get_audit_database_url()
+    result = {
+        'source': 'audit',
+        'log_file': _masked_location(url) if url else 'AUDIT_DATABASE_URL 미설정',
+        'exists': False,
+        'size_bytes': 0,
+        'logs': [],
+    }
+    if not url:
+        return result
+    try:
+        conn = psycopg2.connect(url, connect_timeout=3)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT occurred_at, actor_ip, action, detail FROM audit_log "
+                    "ORDER BY occurred_at DESC, id DESC LIMIT %s",
+                    (lines,),
+                )
+                rows = cur.fetchall()
+        finally:
+            conn.close()
+        result['exists'] = True
+        result['logs'] = [_format_line(*row) for row in reversed(rows)]
+        return result
+    except Exception as e:
+        logger.warning(f'Audit list failed: {e}')
+        return result
+
+
+def _format_line(occurred_at, actor_ip, action, detail) -> str:
+    line = f'[{occurred_at.isoformat()}] {actor_ip} · {action}'
+    if detail and isinstance(detail, dict):
+        changed = detail.get('changed')
+        if changed:
+            diff = ', '.join(f'{key}: {value.get("from")} → {value.get("to")}'
+                             for key, value in changed.items())
+            return f'{line} ({diff})'
+        name = detail.get('name')
+        if name:
+            return f'{line} ({name})'
+    return line
+
+
+def _masked_location(url: str) -> str:
+    """자격증명을 제거한 DB 위치 (뷰어의 파일 경로 자리에 표시)"""
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname or ''
+        port = f':{parts.port}' if parts.port else ''
+        return f'{parts.scheme}://{host}{port}{parts.path}'
+    except Exception:
+        return 'postgresql://(masked)'
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test -q`
+Expected: 89 passed (80 + 9)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add suh-ai-server/flask/service/audit_service.py suh-ai-server/flask/test/test_audit_service.py
+git commit -m "관리 행위 감사로그 : feat : 감사 서비스 및 카테고리·액션 enum 추가 https://github.com/Cassiiopeia/suh-project-control/issues/70"
+```
+
+---
+
+### Task 3: 라우터 기록 지점 + audit 조회 분기 + Swagger
+
+**Files:**
+- Modify: `suh-ai-server/flask/router/palworld_router.py`
+- Modify: `suh-ai-server/flask/router/palworld_swagger.py:70-71` (source enum)
+- Test: `suh-ai-server/flask/test/test_palworld_router.py`
+
+**Interfaces:**
+- Consumes: `audit_service.record/list_logs`, `AuditCategory`, `AuditAction` (Task 2)
+- Produces: `GET /palworld/logs?source=audit` → `list_logs` 응답. start/stop/restart/settings(변경 시)/backup **성공 시에만** `record` 호출.
+
+- [ ] **Step 1: 실패하는 테스트 작성** — `test/test_palworld_router.py` 끝에 추가:
+
+```python
+# --- 감사로그 연동 ---
+
+def test_control_success_records_audit(client):
+    with patch('router.palworld_router.palworld_service.start'), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/start', headers={'X-Forwarded-For': '9.9.9.9, 10.0.0.1'})
+    assert resp.status_code == 200
+    args = mock_record.call_args[0]
+    assert args[1].value == 'SERVER_START'
+    assert args[2] == '9.9.9.9'  # XFF 첫 값
+
+
+def test_control_failure_does_not_record_audit(client):
+    with patch('router.palworld_router.palworld_service.start', side_effect=RuntimeError('boom')), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/start')
+    assert resp.status_code == 500
+    mock_record.assert_not_called()
+
+
+def test_put_settings_records_changed_diff_only(client):
+    before = {'settings': {'ServerName': '"Old"', 'ExpRate': '2.0'}, 'editable_keys': []}
+    after = {'settings': {'ServerName': '"Old"', 'ExpRate': '3.0'}, 'editable_keys': []}
+    with patch('router.palworld_router.palworld_service.get_settings', return_value=before), \
+         patch('router.palworld_router.palworld_service.update_settings', return_value=after), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.put('/palworld/settings', json={'ExpRate': '3.0', 'ServerName': 'Old'})
+    assert resp.status_code == 200
+    detail = mock_record.call_args[0][3]
+    assert detail == {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}
+
+
+def test_put_settings_no_change_skips_audit(client):
+    same = {'settings': {'ExpRate': '2.0'}, 'editable_keys': []}
+    with patch('router.palworld_router.palworld_service.get_settings', return_value=same), \
+         patch('router.palworld_router.palworld_service.update_settings', return_value=same), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.put('/palworld/settings', json={'ExpRate': '2.0'})
+    assert resp.status_code == 200
+    mock_record.assert_not_called()
+
+
+def test_create_backup_records_audit(client):
+    with patch('router.palworld_router.palworld_service.create_backup', return_value={'name': '20260714_1'}), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/backups')
+    assert resp.status_code == 200
+    assert mock_record.call_args[0][1].value == 'BACKUP_CREATE'
+    assert mock_record.call_args[0][3] == {'name': '20260714_1'}
+
+
+def test_logs_source_audit_uses_audit_service(client):
+    fake = {'source': 'audit', 'log_file': 'postgresql://h:5430/db', 'exists': True, 'size_bytes': 0, 'logs': ['x']}
+    with patch('router.palworld_router.audit_service.list_logs', return_value=fake) as mock_list, \
+         patch('router.palworld_router.palworld_service.tail_logs') as mock_tail:
+        resp = client.get('/palworld/logs?source=audit&lines=100')
+    assert resp.status_code == 200
+    assert resp.get_json()['logs'] == ['x']
+    mock_list.assert_called_once_with(100)
+    mock_tail.assert_not_called()
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test/test_palworld_router.py -v -k audit`
+Expected: FAIL — `AttributeError: router.palworld_router에 audit_service 없음`
+
+- [ ] **Step 3: 구현** — `palworld_router.py` 수정:
+
+**(a)** import 블록에 추가 (`from service.palworld_service import ...` 다음 줄):
+
+```python
+from service import audit_service
+from service.audit_service import AuditCategory, AuditAction
+```
+
+**(b)** `palworld_service = PalworldService()` 아래에 헬퍼 추가:
+
+```python
+_CONTROL_AUDIT_ACTIONS = {
+    'start': AuditAction.SERVER_START,
+    'stop': AuditAction.SERVER_STOP,
+    'restart': AuditAction.SERVER_RESTART,
+}
+
+
+def _client_ip() -> str:
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        return forwarded.split(',')[0].strip()
+    return request.remote_addr or 'unknown'
+```
+
+**(c)** `_control` 함수를 교체 (성공 시에만 기록):
+
+```python
+def _control(action_name):
+    try:
+        getattr(palworld_service, action_name)()
+    except Exception as e:
+        logger.error(f"{action_name} error: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+    audit_service.record(AuditCategory.PALWORLD, _CONTROL_AUDIT_ACTIONS[action_name], _client_ip())
+    return jsonify({'success': True, 'action': action_name}), 200
+```
+
+**(d)** `put_settings` 함수를 교체 (변경 diff 계산 — 실제 달라진 키만, 0건이면 기록 생략):
+
+```python
+@palworld_bp.route('/palworld/settings', methods=['PUT'])
+def put_settings():
+    """PalWorldSettings.ini 수정 (서버 가동 중이면 409)"""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({'error': 'JSON body required'}), 400
+    try:
+        before = {}
+        try:
+            before = palworld_service.get_settings()['settings']
+        except Exception:
+            pass  # 이전 값 조회 실패는 감사 diff만 비게 할 뿐 수정은 진행
+        result = palworld_service.update_settings(data)
+        after = result['settings']
+        changed = {
+            key: {'from': before.get(key), 'to': after.get(key)}
+            for key in data
+            if key in after and before.get(key) != after.get(key)
+        }
+        if changed:
+            audit_service.record(AuditCategory.PALWORLD, AuditAction.SETTINGS_UPDATE,
+                                 _client_ip(), {'changed': changed})
+        return jsonify(result), 200
+    except ServerRunningError as e:
+        return jsonify({'error': str(e)}), 409
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+    except Exception as e:
+        logger.error(f"Settings write error: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+```
+
+**(e)** `logs` 함수의 두 번째 try 블록을 교체 — audit 분기는 hide_noise 파싱 **앞**에 둔다:
+
+```python
+    try:
+        source = request.args.get('source', 'game')
+        if source == 'audit':
+            return jsonify(audit_service.list_logs(lines)), 200
+        hide_noise = request.args.get('hide_noise', 'false').lower() in ('1', 'true', 'yes')
+        return jsonify(palworld_service.tail_logs(source, lines, hide_noise)), 200
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+    except Exception as e:
+        logger.error(f"Log read error: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+```
+
+docstring도 갱신: `"""서버 로그 tail (source: audit|events|game|stdout|stderr|flask)"""`
+
+**(f)** `create_backup` 함수를 교체 (성공 시 기록):
+
+```python
+@palworld_bp.route('/palworld/backups', methods=['POST'])
+def create_backup():
+    """즉시 백업 실행"""
+    try:
+        result = palworld_service.create_backup()
+        audit_service.record(AuditCategory.PALWORLD, AuditAction.BACKUP_CREATE,
+                             _client_ip(), {'name': result.get('name')})
+        return jsonify(result), 200
+    except FileNotFoundError as e:
+        return jsonify({'error': str(e)}), 404
+    except Exception as e:
+        logger.error(f"Backup create error: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+```
+
+**(g)** `palworld_swagger.py`의 logs 항목 수정 — enum과 설명 교체:
+
+```python
+                {"name": "source", "in": "query", "required": False,
+                 "schema": {"type": "string", "enum": ["audit", "events", "game", "stdout", "stderr", "flask"], "default": "game"},
+                 "description": "audit=관리 행위 감사로그(DB), events=접속/퇴장 이벤트, game=엔진 로그(stdout 캡처), stderr=NSSM 표준에러, flask=관리자 서버 로그"},
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `PYTHONIOENCODING=utf-8 python -m pytest test -q`
+Expected: 95 passed (89 + 6)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add suh-ai-server/flask/router/palworld_router.py suh-ai-server/flask/router/palworld_swagger.py suh-ai-server/flask/test/test_palworld_router.py
+git commit -m "관리 행위 감사로그 : feat : 서버 제어·설정 수정·백업 감사 기록 및 audit 조회 분기 https://github.com/Cassiiopeia/suh-project-control/issues/70"
+```
+
+---
+
+### Task 4: 프론트 소스 추가 + CICD .env 주입 + 문서
+
+**Files:**
+- Modify: `suh-ai-server/flask/static/js/palworld.js:369-374` (소스 목록 — #62/#65 이후 라벨·flask 소스가 추가된 현재 상태 기준)
+- Modify: `.github/workflows/SUH-AI-PROJECT-CONTROL.yaml` (prepare-and-upload job)
+- Test: 기존 전체 회귀 (`python -m pytest test -q`)
+
+**Interfaces:**
+- Consumes: `GET /palworld/logs?source=audit` (Task 3)
+- Produces: 없음 (말단)
+
+> **⚠️ 로컬 `.env` 생성과 GitHub Secret `FLASK_ENV_FILE` 등록은 이 태스크에 포함되지 않는다** — DB 실자격증명이 필요하므로 **코디네이터가 세션에서 직접** 수행한다. 서브에이전트는 실값을 다루지 않는다.
+
+- [ ] **Step 1: palworld.js 소스 추가** — `initLogViewer()`의 sources 배열을 교체 (기존 4개 소스·라벨 유지, '감사'만 삽입):
+
+```javascript
+    sources: [
+      { id: 'events', label: '이벤트' },
+      { id: 'audit', label: '감사' },
+      { id: 'game', label: '게임 로그' },
+      { id: 'stderr', label: '오류(stderr)' },
+      { id: 'flask', label: '시스템(Flask)' },
+    ],
+```
+
+(`formatLine`은 audit 소스에서 백엔드가 이미 완성 문자열을 내려주므로 변경 불필요 — `source === 'events'` 분기만 유지)
+
+- [ ] **Step 2: CICD .env 주입 스텝 추가** — `SUH-AI-PROJECT-CONTROL.yaml`의 `prepare-and-upload` job에서 `- name: suh-ai-server 폴더 업로드` 스텝 **바로 앞**에 추가 (SCP가 폴더째 올리므로 업로드 전에 파일을 만들어두면 함께 전송된다):
+
+```yaml
+      - name: Flask .env 생성 (GitHub Secret)
+        run: |
+          if [ -n "${{ secrets.FLASK_ENV_FILE }}" ]; then
+            cat > suh-ai-server/flask/.env << 'ENV_EOF'
+          ${{ secrets.FLASK_ENV_FILE }}
+          ENV_EOF
+            echo "[SUCCESS] flask/.env created for upload"
+          else
+            echo "[INFO] FLASK_ENV_FILE secret not set - skip (.env unchanged on server)"
+          fi
+```
+
+- [ ] **Step 3: 전체 회귀 확인**
+
+Run: `cd suh-ai-server/flask && PYTHONIOENCODING=utf-8 python -m pytest test -q`
+Expected: 95 passed
+
+- [ ] **Step 4: Commit (코드 + 문서)**
+
+```bash
+cd "D:\0-suh\project\suh-project-control"
+git add suh-ai-server/flask/static/js/palworld.js .github/workflows/SUH-AI-PROJECT-CONTROL.yaml
+git commit -m "관리 행위 감사로그 : feat : 로그 탭 감사 소스 추가 및 배포 시 .env 주입 https://github.com/Cassiiopeia/suh-project-control/issues/70"
+git add docs/superpowers/specs/2026-07-14-palworld-audit-log-design.md docs/superpowers/plans/2026-07-14-palworld-audit-log.md .issue/palworld-audit-log.md
+git commit -m "관리 행위 감사로그 : docs : 설계 스펙 및 구현 계획 문서 추가 https://github.com/Cassiiopeia/suh-project-control/issues/70"
+```
+
+---
+
+## 코디네이터 직접 수행 항목 (구현 완료 후, push 전)
+
+1. 로컬 `suh-ai-server/flask/.env` 생성 — 사용자 제공 접속정보로 `AUDIT_DATABASE_URL` 1줄 (git status에 안 뜨는지 확인 — Task 1의 .gitignore 검증)
+2. GitHub Secret `FLASK_ENV_FILE` 등록 — `SECRET_VALUE` 환경변수로 .env 내용 전달 (pro-github `secrets set`)
+3. 로컬 스모크: `.env` 있는 상태로 `python app.py` 기동 → `GET /palworld/logs?source=audit` — 실 DB에 연결되면 `exists:true`, 서버 제어 1회 후 감사 라인 확인 (외부 DB 접근 불가 환경이면 `exists:false` + 마스킹 위치 표시 확인으로 대체)
+
+## 배포 메모
+
+- main 머지 → 워크플로우가 `.env` 포함 업로드 + pip install + Flask 재시작 → 기동 시 yoyo가 `audit_log` 생성
+- 확인: 관리자 페이지에서 서버 재시작 1회 → 로그 탭 "감사"에 `SERVER_RESTART` 노출

--- a/docs/superpowers/specs/2026-07-14-palworld-audit-log-design.md
+++ b/docs/superpowers/specs/2026-07-14-palworld-audit-log-design.md
@@ -1,0 +1,151 @@
+# suh-ai-server 감사로그(Audit Log) — PostgreSQL 기록
+
+- 날짜: 2026-07-14
+- 상태: 사용자 승인 대기
+- 관련: `docs/superpowers/specs/2026-07-14-palworld-admin-overhaul-design.md` (어드민 개편, #53)
+
+## 1. 배경 / 목표
+
+팰월드 관리자 페이지는 카톡방에 공유된 단일 API Key로 누구나 서버 제어(시작/중지/재시작)와
+설정 수정이 가능하다. **누가(어느 IP가) 언제 무엇을 바꿨는지** 기록이 없어, 설정이 바뀌거나
+서버가 재시작돼도 추적할 수 없다. 관리 행위를 PostgreSQL에 감사로그로 기록하고 관리자
+페이지에서 조회할 수 있게 한다.
+
+## 2. 확정된 요구사항 (브레인스토밍 결과)
+
+- **기록 대상**: 서버 제어(시작/중지/재시작), 설정 수정(변경 diff 포함), 백업 생성
+- **행위자 식별**: 클라이언트 IP만 (`X-Forwarded-For` 첫 값 → 없으면 `remote_addr`)
+- **저장소**: PostgreSQL `suh_ai_server` DB (기구축: `suh-project.synology.me:5430`, DB는 사용자가 생성 완료)
+- **확장성**: 카테고리(enum) 2단 구조 — 팰월드 외 서비스(OCR/Vision/시스템)도 같은 테이블 사용 가능
+- **enum 방식**: Python 코드 enum + DB는 VARCHAR (Spring `@Enumerated(EnumType.STRING)` 철학 —
+  PG native ENUM은 값 변경 시 ALTER TYPE 필요라 배제)
+- **마이그레이션**: `yoyo-migrations` (순수 SQL 파일 + 이력 테이블, Flyway와 동일 개념, pip 설치)
+- **접속정보**: `flask/.env` (gitignore) + GitHub Secret `FLASK_ENV_FILE` 통째 주입 (CICD가 서버에 파일 생성)
+- **Fail-open**: DB 다운 시 감사 기록만 스킵(warning 로그), 관리 행위 자체는 정상 처리
+- **Redis**: 감사로그에 불필요 — 범위 제외
+
+## 3. DB 설계
+
+### 마이그레이션 `flask/migrations/0001__create_audit_log.sql`
+
+```sql
+CREATE TABLE audit_log (
+    id           BIGSERIAL    PRIMARY KEY,
+    occurred_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    category     VARCHAR(32)  NOT NULL,
+    action       VARCHAR(64)  NOT NULL,
+    actor_ip     VARCHAR(64)  NOT NULL,
+    detail       JSONB        NULL
+);
+
+COMMENT ON TABLE audit_log IS 'suh-ai-server 관리 행위 감사 로그';
+COMMENT ON COLUMN audit_log.category IS '서비스 카테고리 (코드 enum: PALWORLD, SYSTEM, ...)';
+COMMENT ON COLUMN audit_log.action IS '행위 (코드 enum: SERVER_START, SETTINGS_UPDATE, ...)';
+COMMENT ON COLUMN audit_log.detail IS '액션별 부가정보 (설정 변경 diff 등)';
+
+CREATE INDEX idx_audit_log_category_occurred_at
+    ON audit_log (category, occurred_at DESC);
+```
+
+- 적용 이력은 yoyo가 `_yoyo_migration` 테이블로 자체 관리 (Flyway의 `flyway_schema_history` 상당)
+- 마이그레이션은 **앱 기동 시 자동 적용** (`run.py`에서 yoyo apply — Spring Boot + Flyway와 동일한 경험)
+- DB 연결 실패 시 마이그레이션 스킵 + warning, 앱은 정상 기동
+
+### 코드 enum (`service/audit_service.py`)
+
+```python
+class AuditCategory(str, Enum):
+    PALWORLD = "PALWORLD"
+    SYSTEM = "SYSTEM"        # 향후 확장용 예약
+
+class AuditAction(str, Enum):
+    SERVER_START = "SERVER_START"
+    SERVER_STOP = "SERVER_STOP"
+    SERVER_RESTART = "SERVER_RESTART"
+    SETTINGS_UPDATE = "SETTINGS_UPDATE"
+    BACKUP_CREATE = "BACKUP_CREATE"
+```
+
+새 카테고리/액션 추가 = 코드 enum 한 줄 (DB 마이그레이션 불필요).
+
+## 4. 아키텍처
+
+### 4.1 감사 서비스 (`service/audit_service.py` — 신규)
+
+- `record(category: AuditCategory, action: AuditAction, actor_ip: str, detail: dict | None) -> bool`
+  - psycopg2로 동기 INSERT (관리 행위는 하루 수 건 수준 — 큐/배치 불필요)
+  - 커넥션은 호출 시 획득·반납 (`psycopg2` 단순 연결; 빈도가 낮아 풀 불필요)
+  - **예외는 전부 삼키고 warning 로그** — 감사 실패가 관리 행위를 막지 않는다 (fail-open)
+- `list_logs(lines: int) -> dict` — 최근 N건 조회(현재 카테고리가 하나라 필터 없음 — 필요 시 추가), 로그 뷰어 응답 형태로 반환:
+  `{"source": "audit", "exists": bool(DB 연결 성공), "log_file": "postgresql://…/suh_ai_server(마스킹)", "size_bytes": 0, "logs": [문자열...]}`
+  - 각 로그 라인은 백엔드에서 포맷: `[2026-07-14T15:42:45+09:00] 192.168.0.10 · SERVER_RESTART`
+    / 설정 변경은 `... · SETTINGS_UPDATE (ExpRate: 2.0 → 3.0, DeathPenalty: All → Item)`
+  - DB 연결 실패 시 `exists: false` — 기존 뷰어가 "로그 파일이 아직 없습니다: (경로)" 패턴으로 안내
+
+### 4.2 DB 설정 (`config/db_config.py` — 신규)
+
+- `python-dotenv`로 `flask/.env` 로드 (파일 없으면 무시 — 로컬 테스트/CI에서도 기동)
+- `AUDIT_DATABASE_URL` 환경변수 1개: `postgresql://user:pass@host:5430/suh_ai_server`
+- URL 미설정 시 감사 기능 전체 비활성(기록 스킵 + 조회는 `exists:false`) — 서버 없는 환경 대비
+
+### 4.3 라우터 연동 (`router/palworld_router.py` 수정)
+
+- `_client_ip()` 헬퍼: `X-Forwarded-For` 첫 값 → `remote_addr`
+- 기록 지점 (성공 시에만 기록):
+  - `POST /palworld/start|stop|restart` → `SERVER_START|STOP|RESTART`
+  - `PUT /palworld/settings` → `SETTINGS_UPDATE`, detail = `{"changed": {키: {"from": 이전값, "to": 새값}}}`
+    (변경 전 ini를 읽어 diff 계산 — 실제로 달라진 키만 기록, 변경 0건이면 기록 생략)
+  - `POST /palworld/backups` → `BACKUP_CREATE`, detail = `{"name": 백업명}`
+- `GET /palworld/logs?source=audit` → 파일 tail 대신 `audit_service.list_logs()` 분기
+- Swagger: logs source enum에 `audit` 추가
+
+### 4.4 프론트 (`static/js/palworld.js` 수정)
+
+- 로그 뷰어 소스 목록에 `{id: 'audit', label: '감사'}` 추가 — 끝. (응답 형태가 기존과 동일하므로
+  뷰어/포맷 변경 없음)
+
+### 4.5 시크릿/배포
+
+- `flask/.env` (로컬 생성, **커밋 금지**):
+  ```
+  AUDIT_DATABASE_URL=postgresql://<user>:<password>@suh-project.synology.me:5430/suh_ai_server
+  ```
+- `.gitignore`에 `suh-ai-server/flask/.env` 추가
+- GitHub Secret `FLASK_ENV_FILE`: .env 내용 통째 (API로 등록 — 웹/로그 노출 없음)
+- `SUH-AI-PROJECT-CONTROL.yaml`: Flask 재시작 job의 deploy-flask.ps1 실행 **전에** SSH 스텝 추가 —
+  Secret 내용을 `C:\AI\suh-ai-server\flask\.env`로 기록 (Secret 미등록 시 스킵, 기존 파일 유지)
+- `requirements.txt`: `psycopg2-binary`, `yoyo-migrations`, `python-dotenv` 추가
+  (deploy-flask.ps1의 기존 `pip install -r requirements.txt` 스텝이 자동 설치)
+
+## 5. 에러 처리
+
+| 상황 | 동작 |
+|------|------|
+| DB 다운/URL 미설정 상태에서 관리 행위 | 행위는 정상 처리, 감사 기록만 스킵 + warning 로그 |
+| DB 다운 상태에서 감사 탭 조회 | `exists: false` + 마스킹된 DB 위치 안내 (500 아님) |
+| 앱 기동 시 DB 다운 | 마이그레이션 스킵 + warning, 앱 정상 기동 (다음 기동 시 재시도) |
+| detail 직렬화 실패 | fail-open과 동일 — 기록 스킵 + warning |
+| 관리 행위 자체가 실패 (예: start 실패) | 감사 기록하지 않음 (성공한 행위만 기록) |
+
+## 6. 테스트
+
+- `audit_service.record`: 성공 INSERT(mock cursor), DB 예외 시 False 반환 + 행위 비차단(fail-open)
+- settings diff 계산: 변경 키만 추출, 변경 0건 시 기록 생략
+- `_client_ip`: XFF 첫 값 / XFF 없음 → remote_addr
+- 라우터: start 성공 시 record 호출됨(mock), start 실패 시 record 미호출, `source=audit` 분기 응답 형태
+- 마이그레이션 SQL: yoyo 파싱 가능성 (문법 검증)
+- 기존 49개 테스트 회귀 없음
+
+## 7. 범위 제외 (YAGNI)
+
+- 사용자 계정/닉네임 식별 (IP만 — 사용자 결정)
+- Redis 연동
+- 감사로그 보존기간/파티셔닝 (개인 서버 규모에서 불필요)
+- 조회 전용 별도 페이지 (로그 탭 소스로 충분)
+- 실패한 행위 기록 (성공만 기록)
+
+## 8. 배포 체크리스트
+
+1. GitHub Secret `FLASK_ENV_FILE` 등록 (구현 단계에서 API로 처리)
+2. main 머지 → 워크플로우가 .env 생성 + pip install + Flask 재시작 → 기동 시 yoyo가 `audit_log` 테이블 자동 생성
+3. 확인: 서버 재시작 한 번 → 감사 탭에 `SERVER_RESTART` 기록 노출

--- a/suh-ai-server/flask/router/palworld_router.py
+++ b/suh-ai-server/flask/router/palworld_router.py
@@ -4,12 +4,27 @@ Palworld server management router
 from flask import Blueprint, request, jsonify
 from service.palworld_service import PalworldService, ServerRunningError
 from service.palworld_metrics_history import metrics_history
+from service import audit_service
+from service.audit_service import AuditCategory, AuditAction
 import logging
 
 logger = logging.getLogger(__name__)
 
 palworld_bp = Blueprint('palworld', __name__)
 palworld_service = PalworldService()
+
+_CONTROL_AUDIT_ACTIONS = {
+    'start': AuditAction.SERVER_START,
+    'stop': AuditAction.SERVER_STOP,
+    'restart': AuditAction.SERVER_RESTART,
+}
+
+
+def _client_ip() -> str:
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        return forwarded.split(',')[0].strip()
+    return request.remote_addr or 'unknown'
 
 
 @palworld_bp.route('/palworld/status', methods=['GET'])
@@ -25,10 +40,11 @@ def status():
 def _control(action_name):
     try:
         getattr(palworld_service, action_name)()
-        return jsonify({'success': True, 'action': action_name}), 200
     except Exception as e:
         logger.error(f"{action_name} error: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
+    audit_service.record(AuditCategory.PALWORLD, _CONTROL_AUDIT_ACTIONS[action_name], _client_ip())
+    return jsonify({'success': True, 'action': action_name}), 200
 
 
 @palworld_bp.route('/palworld/start', methods=['POST'])
@@ -68,7 +84,22 @@ def put_settings():
     if not data:
         return jsonify({'error': 'JSON body required'}), 400
     try:
-        return jsonify(palworld_service.update_settings(data)), 200
+        before = {}
+        try:
+            before = palworld_service.get_settings()['settings']
+        except Exception:
+            pass  # 이전 값 조회 실패는 감사 diff만 비게 할 뿐 수정은 진행
+        result = palworld_service.update_settings(data)
+        after = result['settings']
+        changed = {
+            key: {'from': before.get(key), 'to': after.get(key)}
+            for key in data
+            if key in after and before.get(key) != after.get(key)
+        }
+        if changed:
+            audit_service.record(AuditCategory.PALWORLD, AuditAction.SETTINGS_UPDATE,
+                                 _client_ip(), {'changed': changed})
+        return jsonify(result), 200
     except ServerRunningError as e:
         return jsonify({'error': str(e)}), 409
     except ValueError as e:
@@ -105,13 +136,15 @@ def history():
 
 @palworld_bp.route('/palworld/logs', methods=['GET'])
 def logs():
-    """서버 로그 tail (source: events|game|stdout|stderr)"""
+    """서버 로그 tail (source: audit|events|game|stdout|stderr|flask)"""
     try:
         lines = int(request.args.get('lines', 200))
     except ValueError:
         return jsonify({'error': 'lines must be an integer'}), 400
     try:
         source = request.args.get('source', 'game')
+        if source == 'audit':
+            return jsonify(audit_service.list_logs(lines)), 200
         hide_noise = request.args.get('hide_noise', 'false').lower() in ('1', 'true', 'yes')
         return jsonify(palworld_service.tail_logs(source, lines, hide_noise)), 200
     except ValueError as e:
@@ -135,7 +168,10 @@ def list_backups():
 def create_backup():
     """즉시 백업 실행"""
     try:
-        return jsonify(palworld_service.create_backup()), 200
+        result = palworld_service.create_backup()
+        audit_service.record(AuditCategory.PALWORLD, AuditAction.BACKUP_CREATE,
+                             _client_ip(), {'name': result.get('name')})
+        return jsonify(result), 200
     except FileNotFoundError as e:
         return jsonify({'error': str(e)}), 404
     except Exception as e:

--- a/suh-ai-server/flask/router/palworld_router.py
+++ b/suh-ai-server/flask/router/palworld_router.py
@@ -19,6 +19,8 @@ _CONTROL_AUDIT_ACTIONS = {
     'restart': AuditAction.SERVER_RESTART,
 }
 
+_SENSITIVE_SETTING_KEYS = {'ServerPassword', 'AdminPassword'}
+
 
 def _client_ip() -> str:
     forwarded = request.headers.get('X-Forwarded-For', '')
@@ -43,7 +45,9 @@ def _control(action_name):
     except Exception as e:
         logger.error(f"{action_name} error: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
-    audit_service.record(AuditCategory.PALWORLD, _CONTROL_AUDIT_ACTIONS[action_name], _client_ip())
+    audit_action = _CONTROL_AUDIT_ACTIONS.get(action_name)
+    if audit_action:
+        audit_service.record(AuditCategory.PALWORLD, audit_action, _client_ip())
     return jsonify({'success': True, 'action': action_name}), 200
 
 
@@ -91,11 +95,13 @@ def put_settings():
             pass  # 이전 값 조회 실패는 감사 diff만 비게 할 뿐 수정은 진행
         result = palworld_service.update_settings(data)
         after = result['settings']
-        changed = {
-            key: {'from': before.get(key), 'to': after.get(key)}
-            for key in data
-            if key in after and before.get(key) != after.get(key)
-        }
+        changed = {}
+        for key in data:
+            if key in after and before.get(key) != after.get(key):
+                if key in _SENSITIVE_SETTING_KEYS:
+                    changed[key] = {'from': '***', 'to': '***'}
+                else:
+                    changed[key] = {'from': before.get(key), 'to': after.get(key)}
         if changed:
             audit_service.record(AuditCategory.PALWORLD, AuditAction.SETTINGS_UPDATE,
                                  _client_ip(), {'changed': changed})

--- a/suh-ai-server/flask/router/palworld_swagger.py
+++ b/suh-ai-server/flask/router/palworld_swagger.py
@@ -81,8 +81,8 @@ PALWORLD_SWAGGER_PATHS = {
             "security": [{"ApiKeyAuth": []}],
             "parameters": [
                 {"name": "source", "in": "query", "required": False,
-                 "schema": {"type": "string", "enum": ["events", "game", "stdout", "stderr", "flask"], "default": "game"},
-                 "description": "events=접속/퇴장 이벤트, game=엔진 로그(stdout 캡처), stderr=NSSM 표준에러, flask=관리자 서버 로그"},
+                 "schema": {"type": "string", "enum": ["audit", "events", "game", "stdout", "stderr", "flask"], "default": "game"},
+                 "description": "audit=관리 행위 감사로그(DB), events=접속/퇴장 이벤트, game=엔진 로그(stdout 캡처), stderr=NSSM 표준에러, flask=관리자 서버 로그"},
                 {"name": "lines", "in": "query", "required": False,
                  "schema": {"type": "integer", "default": 200, "maximum": 500}}
             ],

--- a/suh-ai-server/flask/service/audit_service.py
+++ b/suh-ai-server/flask/service/audit_service.py
@@ -88,10 +88,14 @@ def _format_line(occurred_at, actor_ip, action, detail) -> str:
     line = f'[{occurred_at.isoformat()}] {actor_ip} · {action}'
     if detail and isinstance(detail, dict):
         changed = detail.get('changed')
-        if changed:
-            diff = ', '.join(f'{key}: {value.get("from")} → {value.get("to")}'
-                             for key, value in changed.items())
-            return f'{line} ({diff})'
+        if changed and isinstance(changed, dict):
+            parts = []
+            for key, value in changed.items():
+                if isinstance(value, dict):
+                    parts.append(f'{key}: {value.get("from")} → {value.get("to")}')
+                else:
+                    parts.append(f'{key}: {value}')
+            return f'{line} ({", ".join(parts)})'
         name = detail.get('name')
         if name:
             return f'{line} ({name})'

--- a/suh-ai-server/flask/service/audit_service.py
+++ b/suh-ai-server/flask/service/audit_service.py
@@ -1,0 +1,109 @@
+"""
+관리 행위 감사로그 (PostgreSQL)
+fail-open: DB 다운/URL 미설정이 관리 행위를 절대 막지 않는다.
+category/action은 코드 enum + DB VARCHAR — 새 값 추가 시 마이그레이션 불필요.
+"""
+import logging
+from enum import Enum
+from urllib.parse import urlsplit
+
+import psycopg2
+from psycopg2.extras import Json
+
+from config.db_config import get_audit_database_url
+
+logger = logging.getLogger(__name__)
+
+MAX_LIST_LINES = 500
+
+
+class AuditCategory(str, Enum):
+    PALWORLD = "PALWORLD"
+    SYSTEM = "SYSTEM"  # 향후 확장용
+
+
+class AuditAction(str, Enum):
+    SERVER_START = "SERVER_START"
+    SERVER_STOP = "SERVER_STOP"
+    SERVER_RESTART = "SERVER_RESTART"
+    SETTINGS_UPDATE = "SETTINGS_UPDATE"
+    BACKUP_CREATE = "BACKUP_CREATE"
+
+
+def record(category: AuditCategory, action: AuditAction, actor_ip: str, detail: dict = None) -> bool:
+    url = get_audit_database_url()
+    if not url:
+        return False
+    try:
+        conn = psycopg2.connect(url, connect_timeout=3)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO audit_log (category, action, actor_ip, detail) VALUES (%s, %s, %s, %s)",
+                    (category.value, action.value, actor_ip,
+                     Json(detail) if detail is not None else None),
+                )
+        finally:
+            conn.close()
+        return True
+    except Exception as e:
+        logger.warning(f'Audit record failed ({action}): {e}')
+        return False
+
+
+def list_logs(lines: int = 200) -> dict:
+    """로그 뷰어 응답 형태로 최근 감사로그 반환 (오래된 것 → 최신 순)"""
+    lines = min(int(lines), MAX_LIST_LINES)
+    url = get_audit_database_url()
+    result = {
+        'source': 'audit',
+        'log_file': _masked_location(url) if url else 'AUDIT_DATABASE_URL 미설정',
+        'exists': False,
+        'size_bytes': 0,
+        'logs': [],
+    }
+    if not url:
+        return result
+    try:
+        conn = psycopg2.connect(url, connect_timeout=3)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT occurred_at, actor_ip, action, detail FROM audit_log "
+                    "ORDER BY occurred_at DESC, id DESC LIMIT %s",
+                    (lines,),
+                )
+                rows = cur.fetchall()
+        finally:
+            conn.close()
+        result['exists'] = True
+        result['logs'] = [_format_line(*row) for row in reversed(rows)]
+        return result
+    except Exception as e:
+        logger.warning(f'Audit list failed: {e}')
+        return result
+
+
+def _format_line(occurred_at, actor_ip, action, detail) -> str:
+    line = f'[{occurred_at.isoformat()}] {actor_ip} · {action}'
+    if detail and isinstance(detail, dict):
+        changed = detail.get('changed')
+        if changed:
+            diff = ', '.join(f'{key}: {value.get("from")} → {value.get("to")}'
+                             for key, value in changed.items())
+            return f'{line} ({diff})'
+        name = detail.get('name')
+        if name:
+            return f'{line} ({name})'
+    return line
+
+
+def _masked_location(url: str) -> str:
+    """자격증명을 제거한 DB 위치 (뷰어의 파일 경로 자리에 표시)"""
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname or ''
+        port = f':{parts.port}' if parts.port else ''
+        return f'{parts.scheme}://{host}{port}{parts.path}'
+    except Exception:
+        return 'postgresql://(masked)'

--- a/suh-ai-server/flask/static/js/palworld.js
+++ b/suh-ai-server/flask/static/js/palworld.js
@@ -368,6 +368,7 @@ function initLogViewer() {
   createLogViewer(document.getElementById('palworld-log-viewer'), {
     sources: [
       { id: 'events', label: '이벤트' },
+      { id: 'audit', label: '감사' },
       { id: 'game', label: '게임 로그' },
       { id: 'stderr', label: '오류(stderr)' },
       { id: 'flask', label: '시스템(Flask)' },

--- a/suh-ai-server/flask/test/test_audit_service.py
+++ b/suh-ai-server/flask/test/test_audit_service.py
@@ -91,3 +91,9 @@ def test_format_line_settings_update_shows_diff():
 def test_masked_location_strips_credentials():
     masked = _masked_location(URL)
     assert masked == 'postgresql://suh-project.synology.me:5430/suh_ai_server'
+
+
+def test_format_line_survives_malformed_changed_value():
+    line = _format_line(datetime(2026, 7, 15, 10, 0, 0), '1.2.3.4', 'SETTINGS_UPDATE',
+                        {'changed': {'ExpRate': 'not-a-dict'}})
+    assert 'ExpRate: not-a-dict' in line  # 예외 없이 원값 표시

--- a/suh-ai-server/flask/test/test_audit_service.py
+++ b/suh-ai-server/flask/test/test_audit_service.py
@@ -1,0 +1,93 @@
+"""test_audit_service.py"""
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from service.audit_service import (
+    AuditCategory, AuditAction, record, list_logs, _format_line, _masked_location,
+)
+
+URL = 'postgresql://user:secret@suh-project.synology.me:5430/suh_ai_server'
+
+
+def _mock_conn():
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+# --- record ---
+
+def test_record_returns_false_without_url(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    assert record(AuditCategory.PALWORLD, AuditAction.SERVER_START, '1.2.3.4') is False
+
+
+def test_record_inserts_enum_values(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    conn, cursor = _mock_conn()
+    with patch('service.audit_service.psycopg2.connect', return_value=conn):
+        assert record(AuditCategory.PALWORLD, AuditAction.SETTINGS_UPDATE, '1.2.3.4',
+                      {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}) is True
+    args = cursor.execute.call_args[0]
+    assert 'INSERT INTO audit_log' in args[0]
+    assert args[1][0] == 'PALWORLD'
+    assert args[1][1] == 'SETTINGS_UPDATE'
+    assert args[1][2] == '1.2.3.4'
+
+
+def test_record_fail_open_on_db_error(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    with patch('service.audit_service.psycopg2.connect', side_effect=Exception('down')):
+        assert record(AuditCategory.PALWORLD, AuditAction.SERVER_STOP, '1.2.3.4') is False  # 예외 전파 없음
+
+
+# --- list_logs ---
+
+def test_list_logs_without_url_reports_not_exists(monkeypatch):
+    monkeypatch.delenv('AUDIT_DATABASE_URL', raising=False)
+    result = list_logs(100)
+    assert result['source'] == 'audit'
+    assert result['exists'] is False
+    assert result['logs'] == []
+
+
+def test_list_logs_formats_rows_oldest_first(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    conn, cursor = _mock_conn()
+    cursor.fetchall.return_value = [
+        (datetime(2026, 7, 14, 16, 0, 0), '1.2.3.4', 'SERVER_RESTART', None),
+        (datetime(2026, 7, 14, 15, 0, 0), '5.6.7.8', 'SETTINGS_UPDATE',
+         {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}),
+    ]
+    with patch('service.audit_service.psycopg2.connect', return_value=conn):
+        result = list_logs(100)
+    assert result['exists'] is True
+    assert len(result['logs']) == 2
+    assert 'SETTINGS_UPDATE' in result['logs'][0]      # DESC 조회 → reversed → 오래된 것이 먼저
+    assert 'SERVER_RESTART' in result['logs'][1]
+    assert 'secret' not in result['log_file']           # 자격증명 마스킹
+
+
+def test_list_logs_fail_open_on_db_error(monkeypatch):
+    monkeypatch.setenv('AUDIT_DATABASE_URL', URL)
+    with patch('service.audit_service.psycopg2.connect', side_effect=Exception('down')):
+        result = list_logs(100)
+    assert result['exists'] is False
+
+
+# --- 헬퍼 ---
+
+def test_format_line_settings_update_shows_diff():
+    line = _format_line(datetime(2026, 7, 14, 15, 0, 0), '1.2.3.4', 'SETTINGS_UPDATE',
+                        {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}})
+    assert '1.2.3.4' in line
+    assert 'ExpRate: 2.0 → 3.0' in line
+
+
+def test_masked_location_strips_credentials():
+    masked = _masked_location(URL)
+    assert masked == 'postgresql://suh-project.synology.me:5430/suh_ai_server'

--- a/suh-ai-server/flask/test/test_palworld_router.py
+++ b/suh-ai-server/flask/test/test_palworld_router.py
@@ -158,3 +158,25 @@ def test_logs_source_audit_uses_audit_service(client):
     assert resp.get_json()['logs'] == ['x']
     mock_list.assert_called_once_with(100)
     mock_tail.assert_not_called()
+
+
+def test_put_settings_masks_sensitive_values(client):
+    before = {'settings': {'ServerPassword': '"1234"'}, 'editable_keys': []}
+    after = {'settings': {'ServerPassword': '"5678"'}, 'editable_keys': []}
+    with patch('router.palworld_router.palworld_service.get_settings', return_value=before), \
+         patch('router.palworld_router.palworld_service.update_settings', return_value=after), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.put('/palworld/settings', json={'ServerPassword': '5678'})
+    assert resp.status_code == 200
+    detail = mock_record.call_args[0][3]
+    assert detail == {'changed': {'ServerPassword': {'from': '***', 'to': '***'}}}
+
+
+def test_control_unmapped_action_skips_audit_and_succeeds(client):
+    with patch('router.palworld_router.palworld_service.start'), \
+         patch('router.palworld_router.audit_service.record') as mock_record, \
+         patch.dict('router.palworld_router._CONTROL_AUDIT_ACTIONS', {}, clear=True):
+        resp = client.post('/palworld/start')
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+    mock_record.assert_not_called()

--- a/suh-ai-server/flask/test/test_palworld_router.py
+++ b/suh-ai-server/flask/test/test_palworld_router.py
@@ -96,3 +96,65 @@ def test_guide_returns_info(client):
         resp = client.get('/palworld/guide')
     assert resp.status_code == 200
     assert resp.get_json()['address'] == 'suh-project.synology.me:8211'
+
+
+# --- 감사로그 연동 ---
+
+def test_control_success_records_audit(client):
+    with patch('router.palworld_router.palworld_service.start'), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/start', headers={'X-Forwarded-For': '9.9.9.9, 10.0.0.1'})
+    assert resp.status_code == 200
+    args = mock_record.call_args[0]
+    assert args[1].value == 'SERVER_START'
+    assert args[2] == '9.9.9.9'  # XFF 첫 값
+
+
+def test_control_failure_does_not_record_audit(client):
+    with patch('router.palworld_router.palworld_service.start', side_effect=RuntimeError('boom')), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/start')
+    assert resp.status_code == 500
+    mock_record.assert_not_called()
+
+
+def test_put_settings_records_changed_diff_only(client):
+    before = {'settings': {'ServerName': '"Old"', 'ExpRate': '2.0'}, 'editable_keys': []}
+    after = {'settings': {'ServerName': '"Old"', 'ExpRate': '3.0'}, 'editable_keys': []}
+    with patch('router.palworld_router.palworld_service.get_settings', return_value=before), \
+         patch('router.palworld_router.palworld_service.update_settings', return_value=after), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.put('/palworld/settings', json={'ExpRate': '3.0', 'ServerName': 'Old'})
+    assert resp.status_code == 200
+    detail = mock_record.call_args[0][3]
+    assert detail == {'changed': {'ExpRate': {'from': '2.0', 'to': '3.0'}}}
+
+
+def test_put_settings_no_change_skips_audit(client):
+    same = {'settings': {'ExpRate': '2.0'}, 'editable_keys': []}
+    with patch('router.palworld_router.palworld_service.get_settings', return_value=same), \
+         patch('router.palworld_router.palworld_service.update_settings', return_value=same), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.put('/palworld/settings', json={'ExpRate': '2.0'})
+    assert resp.status_code == 200
+    mock_record.assert_not_called()
+
+
+def test_create_backup_records_audit(client):
+    with patch('router.palworld_router.palworld_service.create_backup', return_value={'name': '20260714_1'}), \
+         patch('router.palworld_router.audit_service.record') as mock_record:
+        resp = client.post('/palworld/backups')
+    assert resp.status_code == 200
+    assert mock_record.call_args[0][1].value == 'BACKUP_CREATE'
+    assert mock_record.call_args[0][3] == {'name': '20260714_1'}
+
+
+def test_logs_source_audit_uses_audit_service(client):
+    fake = {'source': 'audit', 'log_file': 'postgresql://h:5430/db', 'exists': True, 'size_bytes': 0, 'logs': ['x']}
+    with patch('router.palworld_router.audit_service.list_logs', return_value=fake) as mock_list, \
+         patch('router.palworld_router.palworld_service.tail_logs') as mock_tail:
+        resp = client.get('/palworld/logs?source=audit&lines=100')
+    assert resp.status_code == 200
+    assert resp.get_json()['logs'] == ['x']
+    mock_list.assert_called_once_with(100)
+    mock_tail.assert_not_called()


### PR DESCRIPTION
## 관련 이슈

- https://github.com/Cassiiopeia/suh-project-control/issues/70

## 개요

관리 행위(서버 시작/중지/재시작, 설정 수정, 백업 생성)를 PostgreSQL `suh_ai_server` DB의 `audit_log` 테이블에 기록하고, 팰월드 로그 뷰어의 "감사" 탭에서 조회할 수 있게 한다.

## 주요 변경사항

### 감사 기록
- `service/audit_service.py` 신규 — `AuditCategory`/`AuditAction` 코드 enum(+DB VARCHAR, Spring `@Enumerated(STRING)` 철학), `record()` fail-open INSERT, `list_logs()` 로그 뷰어 응답 형태 조회
- `palworld_router.py` — start/stop/restart/settings/backup **성공 시에만** 기록, 행위자 IP(`X-Forwarded-For` → `remote_addr`)
- 설정 변경은 실제로 달라진 키만 `{from → to}` diff로 JSONB 저장, **민감키(`ServerPassword`/`AdminPassword`)는 `***` 마스킹**

### DB / 마이그레이션
- `config/db_config.py` 신규 — `flask/.env`의 `AUDIT_DATABASE_URL` 로드(미설정 시 감사 비활성), yoyo-migrations 기동 시 자동 적용(fail-open)
- `migrations/0001__create_audit_log.sql` — audit_log 테이블 + 카테고리·시각 인덱스 (yoyo `Migration.load()`의 cp949 이슈 대응으로 ASCII-only, 가드 테스트 포함)

### 조회 UI
- `GET /palworld/logs?source=audit` 분기 — 기존 로그 뷰어 재사용, DB 다운 시 `exists:false` + 자격증명 마스킹된 위치 안내
- `palworld.js` 로그 소스에 "감사" 탭 추가

### 시크릿 / 배포
- `.gitignore`에 `suh-ai-server/flask/.env` 추가 (레포 노출 0)
- `SUH-AI-PROJECT-CONTROL.yaml` — GitHub Secret `FLASK_ENV_FILE` → 배포 시 `flask/.env` 동적 생성 (Secret 미설정 시 스킵)
- `requirements.txt` — psycopg2-binary, yoyo-migrations, python-dotenv 추가

## 테스트

- 전체 **99 passed** (감사 관련 신규 24건 포함: fail-open, 성공 시에만 기록, settings diff/마스킹, client_ip, audit 소스 분기, 마이그레이션 ASCII/yoyo 로드 가드)
- 실 DB 연결은 서버 배포 후 자연 검증 (개발망에서 5430 포트 차단)

## 배포 후 확인

1. 기동 시 yoyo가 `audit_log` 테이블 자동 생성
2. 서버 재시작 한 번 → 감사 탭에 `SERVER_RESTART` 기록 노출 확인
